### PR TITLE
feat(og-meta): add open graph meta tags to index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # maevsi - **ALPHA**
 
-A manager for events supported by invitees: [maev.si](https://maev.si/).
+The manager for events supported by invitees: [maev.si](https://maev.si/).
 
 <!-- ![Welcome](images/welcome.jpg "maevsi") -->
 

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -1,11 +1,7 @@
 import bodyParser from 'body-parser'
 import shrinkRay from 'shrink-ray-current'
 
-const STACK_DOMAIN = process.env.NUXT_ENV_STACK_DOMAIN || 'localhost:3000'
-const BASE_URL = // If NUXT_ENV_STACK_DOMAIN is missing, we assume that a http dev env is used.
-  (process.env.NUXT_ENV_STACK_DOMAIN === undefined ? 'http' : 'https') +
-  '://' +
-  STACK_DOMAIN
+import { BASE_URL, STACK_DOMAIN } from './plugins/baseUrl'
 
 export default {
   apollo: {
@@ -83,70 +79,92 @@ export default {
   css: ['vue-croppa/dist/vue-croppa.css', 'vue-datetime/dist/vue-datetime.css'],
 
   // Global page headers (https://go.nuxtjs.dev/config-head)
-  head: {
-    bodyAttrs: { class: 'font-sans h-full dark-mode:text-white' },
-    htmlAttrs: { class: 'h-full' },
-    link: [
-      {
-        href: '/assets/static/favicon/apple-touch-icon.png?v=bOXMwoKlJr',
-        rel: 'apple-touch-icon',
-        sizes: '180x180',
+  head() {
+    return {
+      bodyAttrs: { class: 'font-sans h-full dark-mode:text-white' },
+      htmlAttrs: { class: 'h-full' },
+      link: [
+        {
+          href: '/assets/static/favicon/apple-touch-icon.png?v=bOXMwoKlJr',
+          rel: 'apple-touch-icon',
+          sizes: '180x180',
+        },
+        {
+          href: '/assets/static/favicon/favicon-32x32.png?v=bOXMwoKlJr',
+          rel: 'icon',
+          sizes: '32x32',
+          type: 'image/png',
+        },
+        {
+          href: '/assets/static/favicon/favicon-16x16.png?v=bOXMwoKlJr',
+          rel: 'icon',
+          sizes: '16x16',
+          type: 'image/png',
+        },
+        {
+          href: '/assets/static/favicon/favicon.ico',
+          rel: 'icon',
+          type: 'image/x-icon',
+        },
+        {
+          href: '/assets/static/favicon/site.webmanifest?v=bOXMwoKlJr',
+          rel: 'manifest',
+        },
+        {
+          color: '#202020',
+          href: '/assets/static/favicon/safari-pinned-tab.svg?v=bOXMwoKlJr',
+          rel: 'mask-icon',
+        },
+        {
+          href: '/assets/static/favicon/favicon.ico?v=bOXMwoKlJr',
+          rel: 'shortcut icon',
+        },
+      ],
+      meta: [
+        { charset: 'utf-8' },
+        { content: 'width=device-width, initial-scale=1', name: 'viewport' },
+        {
+          hid: 'description',
+          property: 'description',
+          content: this.$t('globalOgSeoDescription'),
+        },
+        {
+          hid: 'og:description',
+          property: 'og:description',
+          content: this.$t('globalOgSeoDescription'),
+        },
+        {
+          content: '/assets/static/favicon/browserconfig.xml?v=bOXMwoKlJr',
+          name: 'msapplication-config',
+        },
+        {
+          content: '#202020',
+          name: 'msapplication-TileColor',
+        },
+        {
+          content: '#202020',
+          name: 'theme-color',
+        },
+        {
+          hid: 'og:image',
+          property: 'og:image',
+          content: this.$baseUrl + '/assets/static/logos/maevsi.svg',
+        },
+        {
+          hid: 'og:image:alt',
+          property: 'og:image:alt',
+          content: this.$t('globalOgImageAlt'),
+        },
+        {
+          hid: 'og:type',
+          property: 'og:type',
+          content: 'website', // https://ogp.me/#types
+        },
+      ],
+      titleTemplate: (titleChunk) => {
+        return titleChunk ? `${titleChunk} - maevsi` : 'maevsi'
       },
-      {
-        href: '/assets/static/favicon/favicon-32x32.png?v=bOXMwoKlJr',
-        rel: 'icon',
-        sizes: '32x32',
-        type: 'image/png',
-      },
-      {
-        href: '/assets/static/favicon/favicon-16x16.png?v=bOXMwoKlJr',
-        rel: 'icon',
-        sizes: '16x16',
-        type: 'image/png',
-      },
-      {
-        href: '/assets/static/favicon/favicon.ico',
-        rel: 'icon',
-        type: 'image/x-icon',
-      },
-      {
-        href: '/assets/static/favicon/site.webmanifest?v=bOXMwoKlJr',
-        rel: 'manifest',
-      },
-      {
-        color: '#202020',
-        href: '/assets/static/favicon/safari-pinned-tab.svg?v=bOXMwoKlJr',
-        rel: 'mask-icon',
-      },
-      {
-        href: '/assets/static/favicon/favicon.ico?v=bOXMwoKlJr',
-        rel: 'shortcut icon',
-      },
-    ],
-    meta: [
-      { charset: 'utf-8' },
-      { content: 'width=device-width, initial-scale=1', name: 'viewport' },
-      {
-        content: 'A manager for events supported by invitees.',
-        hid: 'description',
-        name: 'description',
-      },
-      {
-        content: '/assets/static/favicon/browserconfig.xml?v=bOXMwoKlJr',
-        name: 'msapplication-config',
-      },
-      {
-        content: '#202020',
-        name: 'msapplication-TileColor',
-      },
-      {
-        content: '#202020',
-        name: 'theme-color',
-      },
-    ],
-    titleTemplate: (titleChunk) => {
-      return titleChunk ? `${titleChunk} - maevsi` : 'maevsi'
-    },
+    }
   },
 
   helmet: {
@@ -192,6 +210,9 @@ export default {
             de: {
               globalApolloLoading: 'Lade...',
               globalAvailabilityNotYet: 'Noch nicht verfügbar.',
+              globalOgImageAlt: 'maevsis Logo.',
+              globalOgSeoDescription:
+                'Das erste Planungstool für Events, die von den Teilnehmenden unterstützt werden können, erleichtert die Organisation von Veranstaltungen.',
               globalPagingMore: 'Mehr',
               globalValidationFormatIncorrect: 'Falsches Format.',
               globalValidationMinValue: 'Wert zu gering.',
@@ -202,6 +223,9 @@ export default {
             en: {
               globalApolloLoading: 'Loading...',
               globalAvailabilityNotYet: 'Not yet available.',
+              globalOgImageAlt: "maevsi's logo.",
+              globalOgSeoDescription:
+                'The first management tool for events, which are supported by invitees, facilitates the organization of events.',
               globalPagingMore: 'More',
               globalValidationFormatIncorrect: 'Incorrect format.',
               globalValidationMinValue: 'Under minimum value.',
@@ -228,6 +252,7 @@ export default {
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
   plugins: [
+    '~/plugins/baseUrl.js',
     '~/plugins/global.js',
     '~/plugins/vuelidate.js',
     '~/plugins/slugify.js',

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.8.0",
   "scheduleVersion": "0.0.3",
+  "description": "The manager for events supported by invitees.",
   "scripts": {
     "dev": "nuxt-ts",
     "build": "nuxt-ts build",

--- a/nuxt/pages/account/_username/index.vue
+++ b/nuxt/pages/account/_username/index.vue
@@ -17,7 +17,21 @@
 <script>
 export default {
   head() {
-    return { title: this.$route.params.username }
+    return {
+      meta: [
+        {
+          hid: 'og:type',
+          property: 'og:type',
+          content: 'profile',
+        },
+        {
+          hid: 'profile:username',
+          property: 'profile:username',
+          content: this.$route.params.username,
+        },
+      ],
+      title: this.$route.params.username,
+    }
   },
   validate({ params }) {
     // Must be a number

--- a/nuxt/pages/event/_username/_event_name.vue
+++ b/nuxt/pages/event/_username/_event_name.vue
@@ -284,6 +284,18 @@ export default {
         this.eventContactFeedbackData.event.name !== null
           ? this.eventContactFeedbackData.event.name
           : '404',
+      meta: [
+        {
+          hid: 'description',
+          property: 'description',
+          content: this.eventContactFeedbackData?.event?.description,
+        },
+        {
+          hid: 'og:description',
+          property: 'og:description',
+          content: this.eventContactFeedbackData?.event?.description,
+        },
+      ],
     }
   },
   validate({ params }) {

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -32,6 +32,50 @@ export default {
   head() {
     return {
       title: this.title,
+      meta: [
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: this.$t('appTitle'),
+        },
+        {
+          hid: 'description',
+          property: 'description',
+          content: this.$t('descriptionSEO'), // @todo: can we fallback to $t('description') ?
+        },
+        {
+          hid: 'og:description',
+          property: 'og:description',
+          content: this.$t('description'),
+        },
+        {
+          hid: 'og:type',
+          property: 'og:type',
+          content: 'website', // https://ogp.me/#types
+        },
+        {
+          hid: 'og:image',
+          property: 'og:image',
+          content: '/assets/static/logos/maevsi.svg',
+        },
+        {
+          hid: 'og:image:alt',
+          property: 'og:image:alt',
+          content: this.$t('logoAlt'),
+        },
+        {
+          hid: 'og:locale',
+          property: 'og:locale',
+          content: this.locale,
+        },
+        ...['de', 'en'] // @todo: where should we define the set of available locales
+          .filter((locale) => locale !== this.locale)
+          .map((locale) => ({
+            hid: 'og:locale:alternate:' + locale,
+            property: 'og:locale:alternate',
+            content: locale,
+          })),
+      ],
     }
   },
 }
@@ -42,12 +86,24 @@ de:
   alpha: 'Diese Webseite befindet sich derzeit im Alpha-Stadium: Alles kann sich jederzeit ändern und Daten können verlorengehen.'
   events: 'Veranstaltungen'
   githubLinkTitle: 'maevsi auf GitHub'
-  maevsi: 'maevsi ist ein Eventmanager für Veranstaltungen, die von Teilnehmenden unterstützt werden.'
   title: 'Willkommen!'
+
+  appTitle: 'Maevsi'
+  maevsi: 'maevsi ist ein Eventmanager für Veranstaltungen, die von Teilnehmenden unterstützt werden.'
+  description: 'maevsi ist ein Eventmanager für Veranstaltungen, die von Teilnehmenden unterstützt werden.'
+  descriptionSEO: 'maevsi ist ein Eventmanager für Veranstaltungen, die von Teilnehmenden unterstützt werden.'
+
+  logoAlt: "Maevsi's wunderschönes Logo."
 en:
   alpha: 'This site is currently in alpha: anything can change at any time and data is volatile.'
   events: 'Events'
   githubLinkTitle: 'maevsi on GitHub'
-  maevsi: 'maevsi is a manager for events supported by invitees.'
   title: 'Welcome!'
+
+  appTitle: 'Maevsi'
+  maevsi: 'maevsi is a manager for events supported by invitees.'
+  description: 'maevsi is a manager for events supported by invitees.'
+  descriptionSEO: 'maevsi is a manager for events supported by invitees.'
+
+  logoAlt: 'The beautiful logo of maevsi.'
 </i18n>

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -32,50 +32,6 @@ export default {
   head() {
     return {
       title: this.title,
-      meta: [
-        {
-          hid: 'og:title',
-          property: 'og:title',
-          content: this.$t('appTitle'),
-        },
-        {
-          hid: 'description',
-          property: 'description',
-          content: this.$t('descriptionSEO'), // @todo: can we fallback to $t('description') ?
-        },
-        {
-          hid: 'og:description',
-          property: 'og:description',
-          content: this.$t('description'),
-        },
-        {
-          hid: 'og:type',
-          property: 'og:type',
-          content: 'website', // https://ogp.me/#types
-        },
-        {
-          hid: 'og:image',
-          property: 'og:image',
-          content: '/assets/static/logos/maevsi.svg',
-        },
-        {
-          hid: 'og:image:alt',
-          property: 'og:image:alt',
-          content: this.$t('logoAlt'),
-        },
-        {
-          hid: 'og:locale',
-          property: 'og:locale',
-          content: this.locale,
-        },
-        ...['de', 'en'] // @todo: where should we define the set of available locales
-          .filter((locale) => locale !== this.locale)
-          .map((locale) => ({
-            hid: 'og:locale:alternate:' + locale,
-            property: 'og:locale:alternate',
-            content: locale,
-          })),
-      ],
     }
   },
 }
@@ -86,24 +42,12 @@ de:
   alpha: 'Diese Webseite befindet sich derzeit im Alpha-Stadium: Alles kann sich jederzeit ändern und Daten können verlorengehen.'
   events: 'Veranstaltungen'
   githubLinkTitle: 'maevsi auf GitHub'
+  maevsi: 'maevsi ist der Eventmanager für Veranstaltungen, die von Teilnehmenden unterstützt werden.'
   title: 'Willkommen!'
-
-  appTitle: 'Maevsi'
-  maevsi: 'maevsi ist ein Eventmanager für Veranstaltungen, die von Teilnehmenden unterstützt werden.'
-  description: 'maevsi ist ein Eventmanager für Veranstaltungen, die von Teilnehmenden unterstützt werden.'
-  descriptionSEO: 'maevsi ist ein Eventmanager für Veranstaltungen, die von Teilnehmenden unterstützt werden.'
-
-  logoAlt: "Maevsi's wunderschönes Logo."
 en:
   alpha: 'This site is currently in alpha: anything can change at any time and data is volatile.'
   events: 'Events'
   githubLinkTitle: 'maevsi on GitHub'
+  maevsi: 'maevsi is the manager for events supported by invitees.'
   title: 'Welcome!'
-
-  appTitle: 'Maevsi'
-  maevsi: 'maevsi is a manager for events supported by invitees.'
-  description: 'maevsi is a manager for events supported by invitees.'
-  descriptionSEO: 'maevsi is a manager for events supported by invitees.'
-
-  logoAlt: 'The beautiful logo of maevsi.'
 </i18n>

--- a/nuxt/plugins/baseUrl.js
+++ b/nuxt/plugins/baseUrl.js
@@ -1,0 +1,10 @@
+export const STACK_DOMAIN =
+  process.env.NUXT_ENV_STACK_DOMAIN || 'localhost:3000'
+export const BASE_URL = // If NUXT_ENV_STACK_DOMAIN is missing, we assume that a http dev env is used.
+  (process.env.NUXT_ENV_STACK_DOMAIN === undefined ? 'http' : 'https') +
+  '://' +
+  STACK_DOMAIN
+
+export default (_, inject) => {
+  inject('baseUrl', BASE_URL)
+}


### PR DESCRIPTION
Add  basic open graph meta tags

This is a static approach for now, including i18n.
I've added both the description and og:description tag with different i18n paths. The description is subject for SEO, but not the og:description.

The url is not overridden.


