### PR TITLE
feat(vue): use typescript for components

### DIFF
--- a/nuxt/components/AppLink.vue
+++ b/nuxt/components/AppLink.vue
@@ -34,8 +34,10 @@
   </nuxt-link>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     append: {
       default: false,
@@ -43,7 +45,7 @@ export default {
     },
     iconId: {
       default: undefined,
-      type: Array,
+      type: Array as PropType<string[] | undefined>,
     },
     isColored: {
       default: true,
@@ -58,5 +60,5 @@ export default {
       type: String,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/Benefit.vue
+++ b/nuxt/components/Benefit.vue
@@ -26,8 +26,10 @@
   </section>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     description: {
       required: true,
@@ -42,5 +44,5 @@ export default {
       type: String,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/Error.vue
+++ b/nuxt/components/Error.vue
@@ -15,34 +15,38 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import status from '@http-util/status-i18n'
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
 
-export default {
+export default defineComponent({
   props: {
     statusCode: {
       default: undefined,
-      type: Number,
+      type: Number as PropType<number | undefined>,
     },
   },
   computed: {
-    statusReason() {
+    statusReason(): string {
       // TODO: https://github.com/http-util/status-i18n/issues/27
-      let statusCodeLanugageCode
+      let statusCodeLanguageCode
 
       switch (this.$i18n.locale) {
         case 'de': // Prepared for https://github.com/http-util/status-i18n/pull/26
-          statusCodeLanugageCode = 'de-de'
+          statusCodeLanguageCode = 'de-de'
           break
         // en captured by `default`
         default:
-          statusCodeLanugageCode = 'en-us'
+          statusCodeLanguageCode = 'en-us'
           break
       }
-      return status(this.statusCode, statusCodeLanugageCode) || this.$t('error')
+      return (
+        status(this.statusCode, statusCodeLanguageCode) ||
+        (this.$t('error') as string)
+      )
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/FooterCategory.vue
+++ b/nuxt/components/FooterCategory.vue
@@ -17,13 +17,15 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     heading: {
       required: true,
       type: String,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/Header.vue
+++ b/nuxt/components/Header.vue
@@ -90,10 +90,12 @@
   </header>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
 const supportedBrowsers = require('~/supportedBrowsers')
 
-export default {
+export default defineComponent({
   data() {
     return {
       isBrowserSupported: true,
@@ -102,7 +104,7 @@ export default {
   beforeMount() {
     this.isBrowserSupported = supportedBrowsers.test(navigator.userAgent)
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/Menu.vue
+++ b/nuxt/components/Menu.vue
@@ -107,15 +107,17 @@
   </nav>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     isClosable: {
       default: false,
       type: Boolean,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/Owner.vue
+++ b/nuxt/components/Owner.vue
@@ -11,8 +11,10 @@
   </i18n>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     link: {
       default: false,
@@ -23,7 +25,7 @@ export default {
       type: String,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/Step.vue
+++ b/nuxt/components/Step.vue
@@ -21,8 +21,10 @@
   </section>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     description: {
       required: true,
@@ -37,5 +39,5 @@ export default {
       type: String,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/TabFlip.vue
+++ b/nuxt/components/TabFlip.vue
@@ -63,8 +63,10 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     dark: {
       default: false,
@@ -73,12 +75,12 @@ export default {
     // `tabIdDefault` must come before `tabIdInitial` as `tabIdInitial` uses `tabIdDefault` data.
     tabIdDefault: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     // `tabs` must come before `tabIdInitial` as `tabIdInitial` uses `tabs` data.
     tabs: {
       required: true,
-      type: Array,
+      type: Array as PropType<string[]>,
     },
     // `queryTabKey` must come before `tabIdInitial` as `tabIdInitial` uses `queryTabKey` data.
     queryTabKey: {
@@ -86,12 +88,15 @@ export default {
       type: String,
     },
     tabIdInitial: {
-      default() {
-        return this.$route.query[this.queryTabKey] === undefined
-          ? this.tabIdDefault
-            ? this.tabIdDefault
-            : this.tabs[0][0]
-          : this.$route.query[this.queryTabKey]
+      default(): string {
+        const queryTabId = this.$route.query[this.queryTabKey]
+        if (!Array.isArray(queryTabId) && queryTabId !== undefined) {
+          return queryTabId
+        }
+        if (this.tabIdDefault !== undefined) {
+          return this.tabIdDefault
+        }
+        return this.tabs[0][0] as string
       },
       type: String,
     },
@@ -102,7 +107,7 @@ export default {
     }
   },
   methods: {
-    tabSelect(tabId) {
+    tabSelect(tabId: string) {
       this.tabIdSelected = tabId // Setting this via `watchQuery` instead would reset all forms.
       this.$emit('tab-id-selected', tabId)
 
@@ -114,7 +119,7 @@ export default {
       }
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/button/Button.vue
+++ b/nuxt/components/button/Button.vue
@@ -32,8 +32,10 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     append: {
       default: false,
@@ -45,7 +47,7 @@ export default {
     },
     buttonClass: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     disabled: {
       default: false,
@@ -53,11 +55,11 @@ export default {
     },
     iconId: {
       default: undefined,
-      type: Array,
+      type: Array as PropType<string[] | undefined>,
     },
     to: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     type: {
       default: 'button',
@@ -66,8 +68,8 @@ export default {
   },
   methods: {
     click() {
-      this.$refs.button.click()
+      ;(this.$refs.button as HTMLButtonElement).click()
     },
   },
-}
+})
 </script>

--- a/nuxt/components/button/ButtonGreen.vue
+++ b/nuxt/components/button/ButtonGreen.vue
@@ -12,8 +12,10 @@
   </Button>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     ariaLabel: {
       required: true,
@@ -29,16 +31,16 @@ export default {
     },
     iconId: {
       default: undefined,
-      type: Array,
+      type: Array as PropType<string[] | undefined>,
     },
     to: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     type: {
       default: 'button',
       type: String,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/button/ButtonIcon.vue
+++ b/nuxt/components/button/ButtonIcon.vue
@@ -11,8 +11,10 @@
   </button>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     ariaLabel: {
       required: true,
@@ -23,19 +25,19 @@ export default {
       type: Boolean,
     },
     iconId: {
-      default() {
+      default(): string[] {
         return []
       },
-      type: Array,
+      type: Array as PropType<string[] | undefined>,
     },
     to: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     type: {
       default: 'button',
       type: String,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/button/ButtonSignIn.vue
+++ b/nuxt/components/button/ButtonSignIn.vue
@@ -17,15 +17,17 @@
   </Button>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     isReferring: {
       default: true,
       type: Boolean,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/button/ButtonTableInteraction.vue
+++ b/nuxt/components/button/ButtonTableInteraction.vue
@@ -9,8 +9,10 @@
   />
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     ariaLabel: {
       required: true,
@@ -22,12 +24,12 @@ export default {
     },
     iconId: {
       required: true,
-      type: Array,
+      type: Array as PropType<string[]>,
     },
     isTitleShow: {
       default: false,
       type: Boolean,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/card/CardAlert.vue
+++ b/nuxt/components/card/CardAlert.vue
@@ -20,19 +20,21 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     errorMessage: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     isEdgy: {
       default: false,
       type: Boolean,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/card/CardInfo.vue
+++ b/nuxt/components/card/CardInfo.vue
@@ -15,13 +15,15 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     isEdgy: {
       default: false,
       type: Boolean,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/card/CardWarn.vue
+++ b/nuxt/components/card/CardWarn.vue
@@ -15,13 +15,15 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     isEdgy: {
       default: false,
       type: Boolean,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/contact/ContactAvatar.vue
+++ b/nuxt/components/contact/ContactAvatar.vue
@@ -8,24 +8,26 @@
   />
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     classes: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     emailAddress: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     emailAddressHash: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     rounded: {
       default: undefined,
-      type: Boolean,
+      type: Boolean as PropType<boolean | undefined>,
     },
     size: {
       required: true,
@@ -33,15 +35,16 @@ export default {
     },
   },
   data() {
+    const graphqlError: string | undefined = undefined
     return {
-      graphqlError: undefined,
+      graphqlError,
     }
   },
   computed: {
-    classComputed() {
+    classComputed(): string {
       return [this.classes, ...(this.rounded ? ['rounded-full'] : [])].join(' ')
     },
-    imageSrc() {
+    imageSrc(): string {
       if (this.emailAddress && this.emailAddressHash) {
         return `https://www.gravatar.com/avatar/${this.emailAddressHash}?d=mp&s=${this.size}`
       } else {
@@ -49,7 +52,7 @@ export default {
       }
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/contact/ContactListItem.vue
+++ b/nuxt/components/contact/ContactListItem.vue
@@ -50,12 +50,15 @@
   </tr>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Contact } from '~/types/contact'
+
+export default defineComponent({
   props: {
     contact: {
       required: true,
-      type: Object,
+      type: Object as PropType<Contact>,
     },
     isDeleting: {
       default: false,
@@ -66,7 +69,7 @@ export default {
       type: Boolean,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/contact/ContactPreview.vue
+++ b/nuxt/components/contact/ContactPreview.vue
@@ -48,19 +48,22 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Contact } from '~/types/contact'
+
+export default defineComponent({
   props: {
     contact: {
       required: true,
-      type: Object,
+      type: Object as PropType<Contact>,
     },
     feedback: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/event/EventIconVisibility.vue
+++ b/nuxt/components/event/EventIconVisibility.vue
@@ -17,15 +17,18 @@
   <FontAwesomeIcon v-else :icon="['fas', 'bug']" :title="$t('bug')" />
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Event } from '~/types/event'
+
+export default defineComponent({
   props: {
     event: {
       required: true,
-      type: Object,
+      type: Object as PropType<Event>,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/event/dashlet/EventDashletAttendanceType.vue
+++ b/nuxt/components/event/dashlet/EventDashletAttendanceType.vue
@@ -21,15 +21,18 @@
   </EventDashlet>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Event } from '~/types/event'
+
+export default defineComponent({
   props: {
     event: {
       required: true,
-      type: Object,
+      type: Object as PropType<Event>,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/event/dashlet/EventDashletDuration.vue
+++ b/nuxt/components/event/dashlet/EventDashletDuration.vue
@@ -9,15 +9,18 @@
   </EventDashlet>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Event } from '~/types/event'
+
+export default defineComponent({
   props: {
     event: {
       required: true,
-      type: Object,
+      type: Object as PropType<Event>,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/event/dashlet/EventDashletLocation.vue
+++ b/nuxt/components/event/dashlet/EventDashletLocation.vue
@@ -18,15 +18,18 @@
   </EventDashlet>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Event } from '~/types/event'
+
+export default defineComponent({
   props: {
     event: {
       required: true,
-      type: Object,
+      type: Object as PropType<Event>,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/event/dashlet/EventDashletStart.vue
+++ b/nuxt/components/event/dashlet/EventDashletStart.vue
@@ -9,15 +9,18 @@
   </EventDashlet>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Event } from '~/types/event'
+
+export default defineComponent({
   props: {
     event: {
       required: true,
-      type: Object,
+      type: Object as PropType<Event>,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/event/dashlet/EventDashletVisibility.vue
+++ b/nuxt/components/event/dashlet/EventDashletVisibility.vue
@@ -14,15 +14,18 @@
   </EventDashlet>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Event } from '~/types/event'
+
+export default defineComponent({
   props: {
     event: {
       required: true,
-      type: Object,
+      type: Object as PropType<Event>,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/event/list/EventListItem.vue
+++ b/nuxt/components/event/list/EventListItem.vue
@@ -45,13 +45,16 @@
   </li>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { Event } from '~/types/event'
+
+export default defineComponent({
   props: {
     event: {
       required: true,
-      type: Object,
+      type: Object as PropType<Event>,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/form/FormCheckbox.vue
+++ b/nuxt/components/form/FormCheckbox.vue
@@ -12,17 +12,19 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     formKey: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     value: {
       default: undefined,
-      type: Boolean,
+      type: Boolean as PropType<boolean | undefined>,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/form/FormRadioButton.vue
+++ b/nuxt/components/form/FormRadioButton.vue
@@ -14,8 +14,10 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     checked: {
       default: false,
@@ -23,7 +25,7 @@ export default {
     },
     groupName: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     title: {
       required: true,
@@ -35,9 +37,9 @@ export default {
     },
   },
   computed: {
-    titleSlug() {
+    titleSlug(): string {
       return this.$slugify(this.title, { lower: true, strict: true })
     },
   },
-}
+})
 </script>

--- a/nuxt/components/form/FormRadioButtonGroup.vue
+++ b/nuxt/components/form/FormRadioButtonGroup.vue
@@ -14,21 +14,23 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     name: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     titlesValues: {
       required: true,
-      type: Array,
+      type: Array as PropType<string[] | string[][]>,
     },
     value: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/form/input/FormInput.vue
+++ b/nuxt/components/form/input/FormInput.vue
@@ -52,8 +52,10 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+const FormInputComponent = defineComponent({
   props: {
     error: {
       default: false,
@@ -65,7 +67,7 @@ export default {
     },
     labelFor: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     required: {
       default: false,
@@ -77,14 +79,17 @@ export default {
     },
     title: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     warning: {
       default: false,
       type: Boolean,
     },
   },
-}
+})
+
+export type FormInput = InstanceType<typeof FormInputComponent>
+export default FormInputComponent
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/form/input/FormInputEmailAddress.vue
+++ b/nuxt/components/form/input/FormInputEmailAddress.vue
@@ -37,16 +37,19 @@
   </FormInput>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { FormInput } from '~/components/form/input/FormInput.vue'
+
+export default defineComponent({
   props: {
     formInput: {
       required: true,
-      type: Object,
+      type: Object as PropType<FormInput>,
     },
     id: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     isOptional: {
       default: false,
@@ -57,7 +60,7 @@ export default {
       type: Boolean,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/form/input/FormInputError.vue
+++ b/nuxt/components/form/input/FormInputError.vue
@@ -16,8 +16,10 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     formInput: {
       default: undefined,
@@ -25,8 +27,8 @@ export default {
     },
     validationProperty: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/form/input/FormInputPassword.vue
+++ b/nuxt/components/form/input/FormInputPassword.vue
@@ -27,8 +27,11 @@
   </FormInput>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { FormInput } from '~/components/form/input/FormInput.vue'
+
+export default defineComponent({
   props: {
     id: {
       required: true,
@@ -36,10 +39,10 @@ export default {
     },
     formInput: {
       required: true,
-      type: Object,
+      type: Object as PropType<FormInput>,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/form/input/FormInputPhoneNumber.vue
+++ b/nuxt/components/form/input/FormInputPhoneNumber.vue
@@ -24,12 +24,15 @@
   </FormInput>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { FormInput } from '~/components/form/input/FormInput.vue'
+
+export default defineComponent({
   props: {
     formInput: {
       required: true,
-      type: Object,
+      type: Object as PropType<FormInput>,
     },
     id: {
       default: 'phone-number',
@@ -40,7 +43,7 @@ export default {
       type: Boolean,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/form/input/FormInputSuccess.vue
+++ b/nuxt/components/form/input/FormInputSuccess.vue
@@ -7,13 +7,16 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { FormInput } from '~/components/form/input/FormInput.vue'
+
+export default defineComponent({
   props: {
     formInput: {
       required: true,
-      type: Object,
+      type: Object as PropType<FormInput>,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/form/input/FormInputUrl.vue
+++ b/nuxt/components/form/input/FormInputUrl.vue
@@ -37,8 +37,11 @@
   </FormInput>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { FormInput } from '~/components/form/input/FormInput.vue'
+
+export default defineComponent({
   props: {
     id: {
       default: 'url',
@@ -46,14 +49,14 @@ export default {
     },
     formInput: {
       required: true,
-      type: Object,
+      type: Object as PropType<FormInput>,
     },
     isOptional: {
       default: false,
       type: Boolean,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/form/input/FormInputUsername.vue
+++ b/nuxt/components/form/input/FormInputUsername.vue
@@ -47,12 +47,15 @@
   </FormInput>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { FormInput } from '~/components/form/input/FormInput.vue'
+
+export default defineComponent({
   props: {
     formInput: {
       required: true,
-      type: Object,
+      type: Object as PropType<FormInput>,
     },
     id: {
       required: true,
@@ -67,7 +70,7 @@ export default {
       type: Boolean,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/invitation/InvitationFeedbackIcon.vue
+++ b/nuxt/components/invitation/InvitationFeedbackIcon.vue
@@ -23,15 +23,17 @@
   <FontAwesomeIcon v-else :icon="['fas', 'bug']" :title="$t('bug')" />
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     feedback: {
       required: true,
       type: String,
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/loader/Loader.vue
+++ b/nuxt/components/loader/Loader.vue
@@ -9,17 +9,19 @@
   <LoaderIndicatorText v-else />
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     errorMessage: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
     indicator: {
       default: undefined,
-      type: String,
+      type: String as PropType<string | undefined>,
     },
   },
-}
+})
 </script>

--- a/nuxt/components/loader/LoaderImage.vue
+++ b/nuxt/components/loader/LoaderImage.vue
@@ -11,8 +11,10 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+
+export default defineComponent({
   props: {
     alt: {
       required: true,
@@ -20,7 +22,7 @@ export default {
     },
     rounded: {
       default: undefined,
-      type: Boolean,
+      type: Boolean as PropType<boolean | undefined>,
     },
     src: {
       required: true,
@@ -29,7 +31,7 @@ export default {
   },
   data() {
     return {
-      srcWhenLoaded: undefined,
+      srcWhenLoaded: undefined as string | undefined,
     }
   },
   async fetch() {
@@ -44,7 +46,7 @@ export default {
     async updateSource() {
       this.srcWhenLoaded = process.server
         ? this.src
-        : await new Promise((resolve) => {
+        : await new Promise<string>((resolve) => {
             const img = new Image()
 
             img.onload = () => {
@@ -55,5 +57,5 @@ export default {
           })
     },
   },
-}
+})
 </script>

--- a/nuxt/components/modal/Modal.vue
+++ b/nuxt/components/modal/Modal.vue
@@ -75,10 +75,13 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent, PropType } from '@nuxtjs/composition-api'
+import { State } from '~/store'
+
 const consola = require('consola')
 
-export default {
+export default defineComponent({
   props: {
     // contentBody is provided by the default slot above.
     id: {
@@ -103,7 +106,7 @@ export default {
     },
     submitTaskProvider: {
       default: () => Promise.resolve(),
-      type: Function,
+      type: Function as PropType<() => Promise<any>>,
     },
   },
   data() {
@@ -115,30 +118,30 @@ export default {
     }
   },
   computed: {
-    contentBodyComputed() {
+    contentBodyComputed(): any {
       return this.$global.getNested(this.modalComputed, 'contentBody') // The default slot above is used as alternative.
     },
-    isVisibleComputed() {
+    isVisibleComputed(): boolean {
       return (
         this.$global.getNested(this.modalComputed, 'isVisible') ||
         this.isVisible
       )
     },
-    onSubmitComputed() {
+    onSubmitComputed(): () => void {
       return (
         this.$global.getNested(this.modalComputed, 'onSubmit') || this.onSubmit
       )
     },
     modalComputed() {
-      const modals = this.$store.state.modals
+      const modals = (this.$store.state as State).modals
 
-      if (!modals || modals.lenght === 0) {
+      if (!modals || modals.length === 0) {
         return undefined
       }
 
       const modalsFiltered = modals.filter((modal) => modal.id === this.id)
 
-      if (!modalsFiltered || modalsFiltered.lenght === 0) {
+      if (!modalsFiltered || modalsFiltered.length === 0) {
         return undefined
       }
 
@@ -169,7 +172,7 @@ export default {
         this.isVisible = false
       }
     },
-    modalKeydowns(e) {
+    modalKeydowns(e: KeyboardEvent) {
       if (!this.isVisible) {
         return
       }
@@ -199,7 +202,7 @@ export default {
       this.isSubmitting = false
     },
   },
-}
+})
 </script>
 
 <i18n lang="yml">

--- a/nuxt/plugins/global.ts
+++ b/nuxt/plugins/global.ts
@@ -113,7 +113,7 @@ export function formPreSubmit(that: any): Promise<void> {
 export function getContactName(
   contact: Contact,
   isUsernamePreferred = false
-): string {
+): string | undefined {
   let name
 
   if (contact.accountUsername) {

--- a/nuxt/types/contact.ts
+++ b/nuxt/types/contact.ts
@@ -1,5 +1,15 @@
 export interface Contact {
-  accountUsername: any
-  firstName: any
-  lastName: string
+  nodeId: string
+
+  authorAccountUsername: string
+  accountUsername?: string
+  firstName?: string
+  lastName?: string
+
+  emailAddress?: string
+  emailAddressHash?: string
+
+  address?: string
+  phoneNumber?: string
+  url?: string
 }

--- a/nuxt/types/event.ts
+++ b/nuxt/types/event.ts
@@ -1,3 +1,15 @@
-export interface Event {
+export type Visibility = 'PUBLIC' | 'PRIVATE'
 
+export interface Event {
+  isArchived: boolean
+  visibility: Visibility
+
+  location: string
+  url?: string
+
+  isInPerson: boolean
+  isRemote: boolean
+
+  start: number
+  end: number
 }

--- a/nuxt/types/event.ts
+++ b/nuxt/types/event.ts
@@ -10,6 +10,6 @@ export interface Event {
   isInPerson: boolean
   isRemote: boolean
 
-  start: number
-  end: number
+  start: string
+  end: string
 }

--- a/nuxt/types/httpUtil.ts
+++ b/nuxt/types/httpUtil.ts
@@ -1,0 +1,6 @@
+declare module '@http-util/status-i18n' {
+  export default function status(
+    statusCode: number | undefined,
+    locale: string
+  ): string | undefined
+}


### PR DESCRIPTION
In this PR I migrated most components to TypeScript, ignoring components that include Apollo.

Once this is merged, I'll use the typed components to update the few remaining pages still using JavaScript and without Apollo integrations.

See #285.