### PR TITLE
refactor: start migration from prop-type to script setup

### DIFF
--- a/nuxt/components/_/Breadcrumbs.vue
+++ b/nuxt/components/_/Breadcrumbs.vue
@@ -34,48 +34,35 @@
   </div>
 </template>
 
-<script lang="ts">
-import { PropType } from 'vue'
-
+<script setup lang="ts">
 import { getQueryString } from '~/plugins/util/util'
 
-interface Breadcrumb {
+export interface Breadcrumb {
   append: boolean
   name: string
   to: string
 }
 
-export default defineComponent({
-  name: 'MaevsiBreadcrumbs',
-  props: {
-    prefixes: {
-      default: undefined,
-      type: Array as PropType<Array<Breadcrumb>>,
-    },
-    suffixes: {
-      default: undefined,
-      type: Array as PropType<Array<Breadcrumb>>,
-    },
-  },
-  setup() {
-    const route = useRoute()
-    const localePath = useLocalePath()
-    const { t } = useI18n()
-
-    const computations = {
-      queryString: computed(() => getQueryString(route.query)),
-    }
-    const methods = {
-      localePath,
-      t,
-    }
-
-    return {
-      ...computations,
-      ...methods,
-    }
-  },
+export interface Props {
+  prefixes?: Array<Breadcrumb>
+  suffixes?: Array<Breadcrumb>
+}
+withDefaults(defineProps<Props>(), {
+  prefixes: undefined,
+  suffixes: undefined,
 })
+
+const route = useRoute()
+const localePath = useLocalePath()
+const { t } = useI18n()
+
+const queryString = computed(() => getQueryString(route.query))
+</script>
+
+<script>
+export default {
+  name: 'MaevsiBreadcrumbs',
+}
 </script>
 
 <i18n lang="yml">

--- a/nuxt/components/_/ImageUploadGallery.vue
+++ b/nuxt/components/_/ImageUploadGallery.vue
@@ -114,13 +114,12 @@
   </Loader>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { Uppy, UploadResult, UppyFile } from '@uppy/core'
 import Tus from '@uppy/tus'
 import consola from 'consola'
 import prettyBytes from 'pretty-bytes'
 import Swal from 'sweetalert2'
-import { PropType } from 'vue'
 
 import {
   useAccountUploadQuotaBytesQuery,
@@ -131,268 +130,246 @@ import { ITEMS_PER_PAGE } from '~/plugins/util/constants'
 import { getApiMeta } from '~/plugins/util/util'
 import { useMaevsiStore } from '~/store'
 
+export interface Props {
+  allowDeletion: boolean
+  selectable: boolean
+  username: string | undefined
+}
+const props = withDefaults(defineProps<Props>(), {
+  allowDeletion: true,
+  selectable: false,
+})
+
+const emit = defineEmits<{
+  (e: 'deletion'): void
+  (e: 'selection', storageKey: string | undefined): void
+}>()
+
 interface Item {
   storageKey: string
 }
 
-export default defineComponent({
-  props: {
-    allowDeletion: {
-      default: true,
-      type: Boolean,
-    },
-    selectable: {
-      default: false,
-      type: Boolean,
-    },
-    username: {
-      required: true,
-      type: String as PropType<string | undefined>,
-    },
+const { t } = useI18n()
+const store = useMaevsiStore()
+const TUSD_FILES_URL = useTusdFilesUrl()
+const config = useRuntimeConfig()
+
+const { executeMutation: executeMutationUploadCreate } =
+  useUploadCreateMutation()
+
+const apiUploadsAfter = ref<string>()
+const croppy = ref()
+
+const allUploadsQuery = useAllUploadsQuery({
+  variables: {
+    after: apiUploadsAfter,
+    username: props.username,
+    first: ITEMS_PER_PAGE,
   },
-  setup(props, { emit }) {
-    const { t } = useI18n()
-    const store = useMaevsiStore()
-    const TUSD_FILES_URL = useTusdFilesUrl()
-    const config = useRuntimeConfig()
+})
+const accountUploadQuotaBytesQuery = useAccountUploadQuotaBytesQuery()
 
-    const { executeMutation: executeMutationUploadCreate } =
-      useUploadCreateMutation()
+const api = computed(() => {
+  return {
+    data: {
+      ...allUploadsQuery.data.value,
+      ...accountUploadQuotaBytesQuery.data.value,
+    },
+    ...getApiMeta([allUploadsQuery, accountUploadQuotaBytesQuery]),
+  }
+})
+const uploads = computed(() => allUploadsQuery.data.value?.allUploads?.nodes)
+const accountUploadQuotaBytes = computed(
+  () => accountUploadQuotaBytesQuery.data.value?.accountUploadQuotaBytes
+)
 
-    const refs = {
-      apiUploadsAfter: ref<string>(),
-      croppy: ref(),
-    }
-    const allUploadsQuery = useAllUploadsQuery({
-      variables: {
-        after: refs.apiUploadsAfter,
-        username: props.username,
-        first: ITEMS_PER_PAGE,
-      },
-    })
-    const accountUploadQuotaBytesQuery = useAccountUploadQuotaBytesQuery()
+const fileSelectedUrl = ref<string | undefined>()
+const jwt = store.jwt
+const selectedItem = ref<Item | undefined>()
+const uppy = ref<Uppy | undefined>()
 
-    const apiData = {
-      api: computed(() => {
-        return {
-          data: {
-            ...allUploadsQuery.data.value,
-            ...accountUploadQuotaBytesQuery.data.value,
-          },
-          ...getApiMeta([allUploadsQuery, accountUploadQuotaBytesQuery]),
-        }
-      }),
-      uploads: computed(() => allUploadsQuery.data.value?.allUploads?.nodes),
-      accountUploadQuotaBytes: computed(
-        () => accountUploadQuotaBytesQuery.data.value?.accountUploadQuotaBytes
-      ),
-    }
-    const data = reactive({
-      fileSelectedUrl: undefined as string | undefined,
-      jwt: store.jwt,
-      selectedItem: undefined as Item | undefined,
-      signedInUsername: store.signedInUsername,
-      uppy: undefined as Uppy | undefined,
-    })
-    const computations = {
-      sizeByteTotal: computed((): number | undefined => {
-        if (!apiData.uploads.value) {
-          return undefined
-        }
+const sizeByteTotal = computed((): number | undefined => {
+  if (!uploads.value) {
+    return undefined
+  }
 
-        let sizeByteTotal = 0
+  let sizeByteTotal = 0
 
-        for (const upload of apiData.uploads.value) {
-          sizeByteTotal += upload.sizeByte
-        }
+  for (const upload of uploads.value) {
+    sizeByteTotal += upload.sizeByte
+  }
 
-        return sizeByteTotal
-      }),
-    }
-    const methods = {
-      bytesToString(
-        bytes: number | string | undefined | null
-      ): string | undefined {
-        if (bytes === undefined || bytes === null) {
-          return undefined
-        }
-        return prettyBytes(+bytes)
-      },
-      changeProfilePicture() {
-        ;(
-          document.querySelector('#input-profile-picture') as HTMLInputElement
-        ).click()
-      },
-      deleteImageUpload(uploadId: string) {
-        const element = document.getElementById(uploadId) as Element
+  return sizeByteTotal
+})
+function bytesToString(
+  bytes: number | string | undefined | null
+): string | undefined {
+  if (bytes === undefined || bytes === null) {
+    return undefined
+  }
+  return prettyBytes(+bytes)
+}
+function changeProfilePicture() {
+  ;(
+    document.querySelector('#input-profile-picture') as HTMLInputElement
+  ).click()
+}
+function deleteImageUpload(uploadId: string) {
+  const element = document.getElementById(uploadId) as Element
 
-        element.classList.add('disabled')
+  element.classList.add('disabled')
 
-        const xhr = new XMLHttpRequest()
+  const xhr = new XMLHttpRequest()
 
-        xhr.open('DELETE', '/api/tusd?uploadId=' + uploadId, true)
-        xhr.setRequestHeader('Hook-Name', 'maevsi/pre-terminate')
-        xhr.setRequestHeader('Authorization', 'Bearer ' + data.jwt)
-        xhr.onreadystatechange = () => {
-          if (xhr.readyState === 4) {
-            element.classList.remove('disabled')
+  xhr.open('DELETE', '/api/tusd?uploadId=' + uploadId, true)
+  xhr.setRequestHeader('Hook-Name', 'maevsi/pre-terminate')
+  xhr.setRequestHeader('Authorization', 'Bearer ' + jwt)
+  xhr.onreadystatechange = () => {
+    if (xhr.readyState === 4) {
+      element.classList.remove('disabled')
 
-            switch (xhr.status) {
-              case 204:
-                // TODO: cache update (allUploads)
-                emit('deletion')
-                break
-              case 500:
-                Swal.fire({
-                  icon: 'error',
-                  text: t('uploadDeleteFailed') as string,
-                  title: t('globalStatusError'),
-                })
-                break
-              default:
-                Swal.fire({
-                  icon: 'warning',
-                  text: t('uploadDeleteUnexpectedStatusCode') as string,
-                  title: t('globalStatusWarning'),
-                })
-            }
-          }
-        }
-        xhr.send()
-      },
-      fileLoaded(e: ProgressEvent<FileReader>) {
-        data.fileSelectedUrl = e.target?.result as string | undefined
-        store.modalAdd({ id: 'ModalImageUploadGallery' })
-      },
-      getUploadImageSrc(uploadStorageKey: string) {
-        return TUSD_FILES_URL + uploadStorageKey + '+'
-      },
-      loadProfilePicture(payload: Event) {
-        const target = payload.target as HTMLInputElement
-        const files = Array.from(target.files ?? [])
-
-        if (files.length !== 1) {
-          return
-        }
-
-        const file = files[0]
-
-        try {
-          const fileReader = new FileReader()
-          fileReader.onload = (e) => methods.fileLoaded(e)
-          fileReader.readAsDataURL(file)
-        } catch (err: any) {
-          if (err.isRestriction) {
-            consola.log('Restriction error: ' + err)
-          } else {
-            consola.error(err)
-          }
-        }
-      },
-      t,
-      toggleSelect(upload: any) {
-        if (data.selectedItem === upload) {
-          data.selectedItem = undefined
-          emit('selection', undefined)
-        } else {
-          data.selectedItem = upload
-          emit('selection', data.selectedItem?.storageKey)
-        }
-      },
-      getUploadBlobPromise() {
-        return new Promise<void>((resolve, reject) => {
-          refs.croppy.value?.promisedBlob().then(async (blob: Blob) => {
-            const result = await executeMutationUploadCreate({
-              uploadCreateInput: {
-                sizeByte: blob.size,
-              },
-            })
-
-            if (result.error) {
-              apiData.api.value.errors.push(result.error)
-              consola.error(result.error)
-              return reject(result.error)
-            }
-
-            if (!result.data) {
-              return
-            }
-
-            data.uppy = new Uppy({
-              id: 'profile-picture',
-              debug: config.public.isInDevelopment,
-              restrictions: {
-                maxFileSize: 1048576,
-                maxNumberOfFiles: 1,
-                minNumberOfFiles: 1,
-                allowedFileTypes: ['image/*'],
-              },
-              meta: {
-                maevsiUploadUuid: result.data.uploadCreate?.uuid,
-              },
-              onBeforeUpload: (files: { [key: string]: UppyFile }) => {
-                const updatedFiles: Record<string, any> = {}
-
-                Object.keys(files).forEach((fileID) => {
-                  updatedFiles[fileID] = {
-                    ...files[fileID],
-                    name: '/profile-pictures/' + files[fileID].name,
-                  }
-                })
-
-                return updatedFiles
-              },
-            })
-
-            data.uppy.use(Tus, {
-              endpoint: TUSD_FILES_URL,
-              limit: 1,
-              removeFingerprintOnSuccess: true,
-            })
-
-            data.uppy.addFile({
-              source: 'croppy',
-              name: (
-                document.querySelector(
-                  '#input-profile-picture'
-                ) as HTMLInputElement
-              ).files![0]!.name,
-              type: blob.type,
-              data: blob,
-            })
-
-            data.uppy.upload().then((value: UploadResult) => {
-              // TODO: cache update (allUploads)
-
-              if (value.failed.length > 0) {
-                reject(t('uploadError'))
-              } else {
-                resolve()
-              }
-            })
+      switch (xhr.status) {
+        case 204:
+          // TODO: cache update (allUploads)
+          emit('deletion')
+          break
+        case 500:
+          Swal.fire({
+            icon: 'error',
+            text: t('uploadDeleteFailed') as string,
+            title: t('globalStatusError'),
           })
-        })
-      },
-    }
-
-    onBeforeUnmount(() => {
-      if (data.uppy) {
-        data.uppy.close()
+          break
+        default:
+          Swal.fire({
+            icon: 'warning',
+            text: t('uploadDeleteUnexpectedStatusCode') as string,
+            title: t('globalStatusWarning'),
+          })
       }
-    })
-
-    watch(allUploadsQuery.error, (currentValue, _oldValue) => {
-      if (currentValue) consola.error(currentValue)
-    })
-
-    return {
-      ...apiData,
-      ...refs,
-      ...data,
-      ...computations,
-      ...methods,
     }
-  },
+  }
+  xhr.send()
+}
+function fileLoaded(e: ProgressEvent<FileReader>) {
+  fileSelectedUrl.value = e.target?.result as string | undefined
+  store.modalAdd({ id: 'ModalImageUploadGallery' })
+}
+function getUploadImageSrc(uploadStorageKey: string) {
+  return TUSD_FILES_URL + uploadStorageKey + '+'
+}
+function loadProfilePicture(payload: Event) {
+  const target = payload.target as HTMLInputElement
+  const files = Array.from(target.files ?? [])
+
+  if (files.length !== 1) {
+    return
+  }
+
+  const file = files[0]
+
+  try {
+    const fileReader = new FileReader()
+    fileReader.onload = (e) => fileLoaded(e)
+    fileReader.readAsDataURL(file)
+  } catch (err: any) {
+    if (err.isRestriction) {
+      consola.log('Restriction error: ' + err)
+    } else {
+      consola.error(err)
+    }
+  }
+}
+function toggleSelect(upload: any) {
+  if (selectedItem === upload) {
+    selectedItem.value = undefined
+    emit('selection', undefined)
+  } else {
+    selectedItem.value = upload
+    emit('selection', selectedItem.value?.storageKey)
+  }
+}
+function getUploadBlobPromise() {
+  return new Promise<void>((resolve, reject) => {
+    croppy.value?.promisedBlob().then(async (blob: Blob) => {
+      const result = await executeMutationUploadCreate({
+        uploadCreateInput: {
+          sizeByte: blob.size,
+        },
+      })
+
+      if (result.error) {
+        api.value.errors.push(result.error)
+        consola.error(result.error)
+        return reject(result.error)
+      }
+
+      if (!result.data) {
+        return
+      }
+
+      uppy.value = new Uppy({
+        id: 'profile-picture',
+        debug: config.public.isInDevelopment,
+        restrictions: {
+          maxFileSize: 1048576,
+          maxNumberOfFiles: 1,
+          minNumberOfFiles: 1,
+          allowedFileTypes: ['image/*'],
+        },
+        meta: {
+          maevsiUploadUuid: result.data.uploadCreate?.uuid,
+        },
+        onBeforeUpload: (files: { [key: string]: UppyFile }) => {
+          const updatedFiles: Record<string, any> = {}
+
+          Object.keys(files).forEach((fileID) => {
+            updatedFiles[fileID] = {
+              ...files[fileID],
+              name: '/profile-pictures/' + files[fileID].name,
+            }
+          })
+
+          return updatedFiles
+        },
+      })
+
+      uppy.value.use(Tus, {
+        endpoint: TUSD_FILES_URL,
+        limit: 1,
+        removeFingerprintOnSuccess: true,
+      })
+
+      uppy.value.addFile({
+        source: 'croppy',
+        name: (
+          document.querySelector('#input-profile-picture') as HTMLInputElement
+        ).files![0]!.name,
+        type: blob.type,
+        data: blob,
+      })
+
+      uppy.value.upload().then((value: UploadResult) => {
+        // TODO: cache update (allUploads)
+
+        if (value.failed.length > 0) {
+          reject(t('uploadError'))
+        } else {
+          resolve()
+        }
+      })
+    })
+  })
+}
+
+onBeforeUnmount(() => {
+  if (uppy.value) {
+    uppy.value.close()
+  }
+})
+
+watch(allUploadsQuery.error, (currentValue, _oldValue) => {
+  if (currentValue) consola.error(currentValue)
 })
 </script>
 


### PR DESCRIPTION
The migration was carried out partially by:
 - Moving the setup function into the script tag
 - Removing the return statement and unwrapping formerly returned objects,
   employing `ref`s

Partially adresses #850