### PR TITLE
fix: :bug: fix menu being empty in between tablet and phone breakpoint

### DIFF
--- a/nuxt/components/_/Menu.vue
+++ b/nuxt/components/_/Menu.vue
@@ -75,7 +75,7 @@
           </ButtonMenu>
         </div>
         <Hr v-if="signedInUsername" class="md:hidden" /> -->
-        <div class="flex flex-col gap-4 md:hidden">
+        <div class="flex flex-col gap-4">
           <ButtonText
             :aria-label="t('eventsExplore')"
             :is-primary="false"


### PR DESCRIPTION
Removes the class that hides the menu content. Since the menu itself is hidden based on the correct breakpoint repeating the hiding of the content is an unnecessary duplication. 

Fixes #816 