### PR TITLE
docs(readme): replace lgtm badge with some github insight badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 [![build status](https://github.com/maevsi/maevsi/workflows/CI/badge.svg)](https://github.com/maevsi/maevsi/actions?query=workflow%3ACI "build status")
-![Snyk Vulnerabilities for GitHub Repo](https://img.shields.io/snyk/vulnerabilities/github/maevsi/maevsi)
-[![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/maevsi/maevsi)](https://github.com/maevsi/maevsi/issues)
-![GitHub commit activity](https://img.shields.io/github/commit-activity/m/maevsi/maevsi)
-![GitHub top language](https://img.shields.io/github/languages/top/maevsi/maevsi)
 
 
 # maevsi

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![build status](https://github.com/maevsi/maevsi/workflows/CI/badge.svg)](https://github.com/maevsi/maevsi/actions?query=workflow%3ACI "build status")
+![Snyk Vulnerabilities for GitHub Repo](https://img.shields.io/snyk/vulnerabilities/github/maevsi/maevsi)
 [![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/maevsi/maevsi)](https://github.com/maevsi/maevsi/issues)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/maevsi/maevsi)
-![GitHub language count](https://img.shields.io/github/languages/count/maevsi/maevsi)
 ![GitHub top language](https://img.shields.io/github/languages/top/maevsi/maevsi)
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![build status](https://github.com/maevsi/maevsi/workflows/CI/badge.svg)](https://github.com/maevsi/maevsi/actions?query=workflow%3ACI "build status")
-[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/maevsi/maevsi.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/maevsi/maevsi/context:javascript)
+[![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/maevsi/maevsi)](https://github.com/maevsi/maevsi/issues)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/m/maevsi/maevsi)
+![GitHub language count](https://img.shields.io/github/languages/count/maevsi/maevsi)
+![GitHub top language](https://img.shields.io/github/languages/top/maevsi/maevsi)
+
 
 # maevsi
 


### PR DESCRIPTION
LGTM is closing end of this year.
They added a banner to their homepage and wrote more about it [here](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/). TLDR: team joined github, added features to githubs code analysis.
This also means that the LGTM badge won't work anymore starting in december.

I looked around, but i didn't find a proper replacement for the language quality badge yet. So, I added some other interesting badges to the readme. Hope it's in your interest.