### PR TITLE
fix(scripts): fix invalid shell in dev.sh

### DIFF
--- a/nuxt/dev.sh
+++ b/nuxt/dev.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
I run into an error getting started with development on alpjha, because set -e is an invalid sh option for me.

I'm not an expert, and it's difficult to me to google this for definite confirmation, but isn't `set -{}` only supported in more suffisticated shells?

Once i replaced the shebang with /bin/bash, it worked fine.
I'd suggest to change this for better interoperability.