### PR TITLE
fix(auth): use secure cookie only in production

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -40,7 +40,7 @@ export default defineNuxtConfig({
                 de: 'Authentifizierungsdaten',
                 en: 'Authentication Data',
               },
-              targetCookieIds: [JWT_NAME],
+              targetCookieIds: [JWT_NAME()],
             },
             {
               description: {

--- a/nuxt/server/api/auth.ts
+++ b/nuxt/server/api/auth.ts
@@ -46,7 +46,7 @@ export default defineEventHandler(async function (event: H3Event) {
 
   res.setHeader(
     'Set-Cookie',
-    serialize(JWT_NAME, jwt, {
+    serialize(JWT_NAME(), jwt, {
       expires: jwt ? new Date(Date.now() + 86400 * 1000 * 31) : new Date(0),
       httpOnly: true,
       path: '/',

--- a/nuxt/utils/auth.ts
+++ b/nuxt/utils/auth.ts
@@ -50,13 +50,14 @@ export async function authenticationAnonymous({
 export function getJwtFromCookie({ req }: { req: IncomingMessage }) {
   if (req.headers.cookie) {
     const cookies = parse(req.headers.cookie)
+    const jwtName = JWT_NAME()
 
-    if (cookies[JWT_NAME]) {
-      const cookie = decodeJwt(cookies[JWT_NAME])
+    if (cookies[jwtName]) {
+      const cookie = decodeJwt(cookies[jwtName])
 
       if (cookie.exp !== undefined && cookie.exp > Date.now() / 1000) {
         return {
-          jwt: cookies[JWT_NAME],
+          jwt: cookies[jwtName],
           jwtDecoded: cookie,
         }
       } else {
@@ -116,7 +117,7 @@ export async function jwtStore({
   if (process.server) {
     res?.setHeader(
       'Set-Cookie',
-      serialize(JWT_NAME, jwt || '', {
+      serialize(JWT_NAME(), jwt || '', {
         expires: jwt ? new Date(Date.now() + 86400 * 1000 * 31) : new Date(0),
         httpOnly: true,
         path: '/',

--- a/nuxt/utils/constants.ts
+++ b/nuxt/utils/constants.ts
@@ -4,7 +4,8 @@ export const CYPRESS_BASE_URL = 'http://localhost:3000'
 export const ITEMS_PER_PAGE = 8
 export const ITEMS_PER_PAGE_LARGE = 100
 export const JWT_ALGORITHM = 'RS256'
-export const JWT_NAME = '__Secure-jwt'
+export const JWT_NAME = () =>
+  `${process.env.NODE_ENV === 'production' ? '__Secure-' : ''}jwt`
 export const LOCALES: LocaleObject[] = [
   {
     code: 'en',


### PR DESCRIPTION
Chrome would block cookies prefixed with `__Secure-` in non-https contexts.

Resolves #1010.