### PR TITLE
refactor(api-data): simplify getter

### DIFF
--- a/nuxt/components/_/ImageUploadGallery.vue
+++ b/nuxt/components/_/ImageUploadGallery.vue
@@ -147,14 +147,13 @@ const config = useRuntimeConfig()
 const TUSD_FILES_URL = useTusdFilesUrl()
 const localePath = useLocalePath()
 const fireAlert = useFireAlert()
-const { executeMutation: executeMutationUploadCreate } =
-  useUploadCreateMutation()
 
 // refs
 const after = ref<string>()
 const cropperRef = ref()
 
-// queries
+// api data
+const accountUploadQuotaBytesQuery = await useAccountUploadQuotaBytesQuery()
 const allUploadsQuery = await useAllUploadsQuery({
   variables: {
     after,
@@ -162,18 +161,12 @@ const allUploadsQuery = await useAllUploadsQuery({
     first: ITEMS_PER_PAGE,
   },
 })
-const accountUploadQuotaBytesQuery = await useAccountUploadQuotaBytesQuery()
-
-// api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...allUploadsQuery.data.value,
-      ...accountUploadQuotaBytesQuery.data.value,
-    },
-    ...getApiMeta([allUploadsQuery, accountUploadQuotaBytesQuery]),
-  })
-)
+const uploadCreateMutation = useUploadCreateMutation()
+const api = getApiData([
+  accountUploadQuotaBytesQuery,
+  allUploadsQuery,
+  uploadCreateMutation,
+])
 const uploads = computed(() => allUploadsQuery.data.value?.allUploads?.nodes)
 const accountUploadQuotaBytes = computed(
   () => accountUploadQuotaBytesQuery.data.value?.accountUploadQuotaBytes
@@ -331,23 +324,14 @@ function toggleSelect(upload: any) {
 function getUploadBlobPromise() {
   return new Promise<void>((resolve, reject) => {
     cropperRef.value?.getResult().canvas?.toBlob(async (blob: Blob) => {
-      api.value.errors = []
-
-      const result = await executeMutationUploadCreate({
+      const result = await uploadCreateMutation.executeMutation({
         uploadCreateInput: {
           sizeByte: blob.size,
         },
       })
 
-      if (result.error) {
-        api.value.errors.push(result.error)
-        consola.error(result.error)
-        return reject(result.error)
-      }
-
-      if (!result.data) {
-        return
-      }
+      if (result.error) return reject(result.error)
+      if (!result.data) return
 
       uppy.value = new Uppy({
         id: 'profile-picture',
@@ -408,9 +392,6 @@ onBeforeUnmount(() => {
   if (uppy.value) {
     uppy.value.close()
   }
-})
-watch(allUploadsQuery.error, (currentValue, _oldValue) => {
-  if (currentValue) consola.error(currentValue)
 })
 </script>
 

--- a/nuxt/components/account/AccountProfilePicture.vue
+++ b/nuxt/components/account/AccountProfilePicture.vue
@@ -12,8 +12,6 @@
 </template>
 
 <script setup lang="ts">
-import consola from 'consola'
-
 import { useProfilePictureByUsernameQuery } from '~/gql/generated'
 import blankProfilePicture from '~/assets/images/blank-profile-picture.svg'
 
@@ -32,22 +30,13 @@ const props = withDefaults(defineProps<Props>(), {
 const { t } = useI18n()
 const TUSD_FILES_URL = useTusdFilesUrl()
 
-// queries
+// api data
 const profilePictureQuery = await useProfilePictureByUsernameQuery({
   variables: {
     username: props.username,
   },
 })
-
-// api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...profilePictureQuery.data.value,
-    },
-    ...getApiMeta([profilePictureQuery]),
-  })
-)
+const api = getApiData([profilePictureQuery])
 
 // computations
 const profilePicture = computed(
@@ -58,11 +47,6 @@ const profilePictureUrl = computed(() =>
     ? TUSD_FILES_URL + profilePicture.value.uploadStorageKey + '+'
     : undefined
 )
-
-// lifecycle
-watch(profilePictureQuery.error, (currentValue, _oldValue) => {
-  if (currentValue) consola.error(currentValue)
-})
 </script>
 
 <i18n lang="yaml">

--- a/nuxt/components/event/list/EventList.vue
+++ b/nuxt/components/event/list/EventList.vue
@@ -24,8 +24,6 @@
 </template>
 
 <script setup lang="ts">
-import consola from 'consola'
-
 import { useAllEventsQuery } from '~/gql/generated'
 
 export interface Props {
@@ -41,7 +39,7 @@ const { t } = useI18n()
 // refs
 const after = ref<string>()
 
-// queries
+// api data
 const eventsQuery = await useAllEventsQuery({
   variables: {
     after,
@@ -49,16 +47,7 @@ const eventsQuery = await useAllEventsQuery({
     first: ITEMS_PER_PAGE,
   },
 })
-
-// api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...eventsQuery.data.value,
-    },
-    ...getApiMeta([eventsQuery]),
-  })
-)
+const api = getApiData([eventsQuery])
 const events = computed(() => eventsQuery.data.value?.allEvents?.nodes)
 
 // data
@@ -66,11 +55,6 @@ const isButtonEventListShown = ref(
   typeof route.name === 'string' &&
     route.name?.replace(/___.+$/, '') !== 'event'
 )
-
-// lifecycle
-watch(eventsQuery.error, (currentValue, _oldValue) => {
-  if (currentValue) consola.error(currentValue)
-})
 </script>
 
 <i18n lang="yaml">

--- a/nuxt/components/form/Form.vue
+++ b/nuxt/components/form/Form.vue
@@ -43,7 +43,7 @@
 <script setup lang="ts">
 import type { BaseValidation } from '@vuelidate/core'
 
-import { BackendError } from '~/utils/util'
+import { BackendError } from '~/types/types'
 
 export interface Props {
   errors?: BackendError[]

--- a/nuxt/components/form/FormContact.vue
+++ b/nuxt/components/form/FormContact.vue
@@ -107,22 +107,7 @@
 <script setup lang="ts">
 import { useVuelidate } from '@vuelidate/core'
 import { email, helpers, maxLength } from '@vuelidate/validators'
-import consola from 'consola'
 
-import {
-  formPreSubmit,
-  validateUsername,
-  VALIDATION_ADDRESS_LENGTH_MAXIMUM,
-  VALIDATION_EMAIL_ADDRESS_LENGTH_MAXIMUM,
-  VALIDATION_EVENT_URL_LENGTH_MAXIMUM,
-  VALIDATION_FIRST_NAME_LENGTH_MAXIMUM,
-  VALIDATION_FORMAT_PHONE_NUMBER,
-  VALIDATION_FORMAT_SLUG,
-  VALIDATION_FORMAT_UPPERCASE_NONE,
-  VALIDATION_FORMAT_URL_HTTPS,
-  VALIDATION_LAST_NAME_LENGTH_MAXIMUM,
-  VALIDATION_USERNAME_LENGTH_MAXIMUM,
-} from '~/utils/validation'
 import {
   Contact,
   useCreateContactMutation,
@@ -142,19 +127,12 @@ const emit = defineEmits<{
 }>()
 
 const store = useMaevsiStore()
-const updateContactByIdMutation = useUpdateContactByIdMutation()
-const createContactMutation = useCreateContactMutation()
 const { t } = useI18n()
 
 // api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...updateContactByIdMutation.data.value,
-    },
-    ...getApiMeta([updateContactByIdMutation]),
-  })
-)
+const createContactMutation = useCreateContactMutation()
+const updateContactByIdMutation = useUpdateContactByIdMutation()
+const api = getApiData([createContactMutation, updateContactByIdMutation])
 
 // data
 const form = reactive({
@@ -171,12 +149,7 @@ const isFormSent = ref(false)
 
 // methods
 async function submit() {
-  try {
-    await formPreSubmit(api, v$, isFormSent)
-  } catch (error) {
-    consola.error(error)
-    return
-  }
+  if (!(await isFormValid({ v$, isFormSent }))) return
 
   if (form.id) {
     // Edit
@@ -194,14 +167,7 @@ async function submit() {
       },
     })
 
-    if (result.error) {
-      api.value.errors.push(result.error)
-      consola.error(result.error)
-    }
-
-    if (!result.data) {
-      return
-    }
+    if (result.error || !result.data) return
 
     emit('submitSuccess')
   } else {
@@ -219,14 +185,7 @@ async function submit() {
       },
     })
 
-    if (result.error) {
-      api.value.errors.push(result.error)
-      consola.error(result.error)
-    }
-
-    if (!result.data) {
-      return
-    }
+    if (result.error || !result.data) return
 
     emit('submitSuccess')
   }
@@ -238,9 +197,6 @@ function updateForm(data?: Pick<Contact, any>) {
     ;(form as Record<string, any>)[k] = v
   }
 }
-
-// initialization
-updateForm(props.contact)
 
 // vuelidate
 const rules = {
@@ -281,6 +237,9 @@ watch(
     updateForm(currentValue)
   }
 )
+
+// initialization
+updateForm(props.contact)
 </script>
 
 <i18n lang="yaml">

--- a/nuxt/components/loader/Loader.vue
+++ b/nuxt/components/loader/Loader.vue
@@ -16,10 +16,8 @@
 <script setup lang="ts">
 import { UnwrapRef } from 'vue'
 
-import { ApiData } from '~/utils/util'
-
 export interface Props {
-  api: UnwrapRef<ApiData>
+  api: UnwrapRef<ReturnType<typeof getApiData>>
   errorPgIds?: Record<string, string>
   classes?: string
   indicator?: string

--- a/nuxt/components/modal/ModalImageSelection.vue
+++ b/nuxt/components/modal/ModalImageSelection.vue
@@ -17,8 +17,6 @@
 </template>
 
 <script setup lang="ts">
-import consola from 'consola'
-
 import { useProfilePictureSetMutation } from '~/gql/generated'
 
 const emit = defineEmits<{
@@ -26,19 +24,12 @@ const emit = defineEmits<{
 }>()
 
 const route = useRoute()
-const profilePictureSetMutation = useProfilePictureSetMutation()
 const config = useRuntimeConfig()
 const { t } = useI18n()
 
 // api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...profilePictureSetMutation.data.value,
-    },
-    ...getApiMeta([profilePictureSetMutation]),
-  })
-)
+const profilePictureSetMutation = useProfilePictureSetMutation()
+getApiData([profilePictureSetMutation])
 
 // data
 const isTesting = config.public.isTesting
@@ -50,16 +41,9 @@ function selectProfilePictureStorageKey(storageKey?: string) {
   selectedProfilePictureStorageKey.value = storageKey
 }
 async function setProfilePicture() {
-  api.value.errors = []
-
-  const result = await profilePictureSetMutation.executeMutation({
+  await profilePictureSetMutation.executeMutation({
     storageKey: selectedProfilePictureStorageKey.value || '',
   })
-
-  if (result.error) {
-    api.value.errors.push(result.error)
-    consola.error(result.error)
-  }
 }
 </script>
 

--- a/nuxt/composables/useFireAlert.ts
+++ b/nuxt/composables/useFireAlert.ts
@@ -6,7 +6,6 @@ export const useFireAlert = () => {
   const { t } = useI18n()
 
   return ({
-    api,
     error,
     level,
     text,
@@ -19,7 +18,6 @@ export const useFireAlert = () => {
     title?: string
   }) => {
     if (error) {
-      api?.value.errors.push(error)
       consola.error(error)
     }
 

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -161,6 +161,7 @@ export default defineNuxtConfig({
     tsConfig: {
       compilerOptions: {
         esModuleInterop: true,
+        // noErrorTruncation: true,
         types: ['jest'],
       },
       vueCompilerOptions: {

--- a/nuxt/pages/account/[username]/settings/index.vue
+++ b/nuxt/pages/account/[username]/settings/index.vue
@@ -86,11 +86,10 @@ const { signOut } = useSignOut()
 const { t } = useI18n()
 const localePath = useLocalePath()
 const route = useRoute()
-const { executeMutation: executeMutationAccoutDelete } =
-  useAccountDeleteMutation()
+const accountDeleteMutation = useAccountDeleteMutation()
 
 // data
-const mutation = executeMutationAccoutDelete
+const mutation = accountDeleteMutation
 const routeParamUsername = route.params.username as string
 const title = route.params.username as string
 

--- a/nuxt/pages/event/[username]/[event_name]/attendance/index.vue
+++ b/nuxt/pages/event/[username]/[event_name]/attendance/index.vue
@@ -109,15 +109,13 @@ const store = useMaevsiStore()
 const route = useRoute()
 const fireAlert = useFireAlert()
 
-// queries
+// api data
 const eventQuery = await useEventByAuthorUsernameAndSlugQuery({
   variables: {
     authorUsername: route.params.username as string,
     slug: route.params.event_name as string,
   },
 })
-
-// api data
 const event = computed(
   () => eventQuery.data.value?.eventByAuthorUsernameAndSlug
 )
@@ -257,9 +255,6 @@ onMounted(() => {
   checkWriteTag().catch((err: Error) => {
     isNfcWritableErrorMessage.value = err.message
   })
-})
-watch(eventQuery.error, (currentValue, _oldValue) => {
-  if (currentValue) consola.error(currentValue)
 })
 
 // initialization

--- a/nuxt/pages/event/[username]/[event_name]/invitation/index.vue
+++ b/nuxt/pages/event/[username]/[event_name]/invitation/index.vue
@@ -28,7 +28,6 @@
 </template>
 
 <script setup lang="ts">
-import consola from 'consola'
 import { useEventByAuthorUsernameAndSlugQuery } from '~/gql/generated'
 import EVENT_IS_EXISTING_QUERY from '~/gql/query/event/eventIsExisting.gql'
 import { useMaevsiStore } from '~/store'
@@ -65,23 +64,14 @@ const route = useRoute()
 const { t } = useI18n()
 const localePath = useLocalePath()
 
-// queries
+// api data
 const eventQuery = await useEventByAuthorUsernameAndSlugQuery({
   variables: {
     authorUsername: route.params.username as string,
     slug: route.params.event_name as string,
   },
 })
-
-// api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...eventQuery.data.value,
-    },
-    ...getApiMeta([eventQuery]),
-  })
-)
+const api = getApiData([eventQuery])
 const event = computed(
   () => eventQuery.data.value?.eventByAuthorUsernameAndSlug
 )
@@ -95,11 +85,6 @@ const title = computed(() => {
   if (!event.value) return t('title')
 
   return `${t('title')} · ${event.value.name}`
-})
-
-// lifecycle
-watch(eventQuery.error, (currentValue, _oldValue) => {
-  if (currentValue) consola.error(currentValue)
 })
 
 // initialization

--- a/nuxt/pages/event/[username]/[event_name]/settings/index.vue
+++ b/nuxt/pages/event/[username]/[event_name]/settings/index.vue
@@ -46,8 +46,6 @@
 </template>
 
 <script setup lang="ts">
-import consola from 'consola'
-
 import {
   useEventByAuthorUsernameAndSlugQuery,
   useEventDeleteMutation,
@@ -86,31 +84,22 @@ definePageMeta({
 const localePath = useLocalePath()
 const { t } = useI18n()
 const route = useRoute()
-const { executeMutation: executeMutationEventDelete } = useEventDeleteMutation()
 
-// queries
+// api data
 const eventQuery = await useEventByAuthorUsernameAndSlugQuery({
   variables: {
     authorUsername: route.params.username as string,
     slug: route.params.event_name as string,
   },
 })
-
-// api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...eventQuery.data.value,
-    },
-    ...getApiMeta([eventQuery]),
-  })
-)
+const eventDeleteMutation = useEventDeleteMutation()
+const api = getApiData([eventQuery, eventDeleteMutation])
 const event = computed(
   () => eventQuery.data.value?.eventByAuthorUsernameAndSlug
 )
 
 // data
-const mutation = executeMutationEventDelete
+const mutation = eventDeleteMutation
 const routeParamEventName = route.params.event_name as string
 const routeParamUsername = route.params.username as string
 
@@ -119,11 +108,6 @@ const title = computed(() => {
   if (!event.value) return t('title')
 
   return `${t('title')} · ${event.value.name}`
-})
-
-// lifecycle
-watch(eventQuery.error, (currentValue, _oldValue) => {
-  if (currentValue) consola.error(currentValue)
 })
 
 // initialization

--- a/nuxt/pages/task/account/email-address/verify.vue
+++ b/nuxt/pages/task/account/email-address/verify.vue
@@ -12,8 +12,6 @@
 </template>
 
 <script setup lang="ts">
-import consola from 'consola'
-
 import { useAccountEmailAddressVerificationMutation } from '~/gql/generated'
 
 definePageMeta({
@@ -37,32 +35,14 @@ const localePath = useLocalePath()
 const { t } = useI18n()
 const route = useRoute()
 const fireAlert = useFireAlert()
-const accountEmailAddressVerificationMutation =
-  useAccountEmailAddressVerificationMutation()
 
 // api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...accountEmailAddressVerificationMutation.data.value,
-    },
-    ...getApiMeta([accountEmailAddressVerificationMutation]),
-  })
-)
+const accountEmailAddressVerificationMutation =
+  useAccountEmailAddressVerificationMutation()
+const api = getApiData([accountEmailAddressVerificationMutation])
 
 // data
 const title = t('title')
-
-// lifecycle
-// TODO: watch all api errors like this (https://github.com/maevsi/maevsi/issues/961)
-watch(
-  () => api.value.errors,
-  (currentValue, oldValue) => {
-    currentValue
-      .filter((c) => !oldValue.includes(c))
-      .forEach((c) => consola.error(c))
-  }
-)
 
 // initialization
 useHeadDefault(title)

--- a/nuxt/pages/task/event/unlock.vue
+++ b/nuxt/pages/task/event/unlock.vue
@@ -166,18 +166,11 @@ const localePath = useLocalePath()
 const { t } = useI18n()
 const route = useRoute()
 const fireAlert = useFireAlert()
-const eventUnlockMutation = useEventUnlockMutation()
 const config = useRuntimeConfig()
 
 // api data
-const api = computed(() =>
-  reactive({
-    data: {
-      ...eventUnlockMutation.data.value,
-    },
-    ...getApiMeta([eventUnlockMutation]),
-  })
-)
+const eventUnlockMutation = useEventUnlockMutation()
+const api = getApiData([eventUnlockMutation])
 
 // data
 const form = reactive({
@@ -188,12 +181,7 @@ const title = t('title')
 
 // methods
 async function submit() {
-  try {
-    await formPreSubmit(api, v$, isFormSent)
-  } catch (error) {
-    consola.error(error)
-    return
-  }
+  if (!isFormValid({ v$, isFormSent })) return
 
   const result = await eventUnlockMutation.executeMutation({
     invitationCode: form.invitationCode,
@@ -243,9 +231,6 @@ onMounted(() => {
       submit()
     }
   }
-})
-watch(eventUnlockMutation.error, (currentValue, _oldValue) => {
-  if (currentValue) consola.error(currentValue)
 })
 
 // initialization

--- a/nuxt/types/types.ts
+++ b/nuxt/types/types.ts
@@ -1,0 +1,15 @@
+import { CombinedError } from '@urql/core'
+import { GraphQLError } from 'graphql'
+
+export type ArrayElement<ArrayType extends readonly unknown[]> =
+  ArrayType extends readonly (infer ElementType)[] ? ElementType : never
+
+export type BackendError = {
+  graphQLErrors: (GraphQLError & { originalError?: { errcode?: string } })[]
+} & CombinedError
+
+export type UnionToIntersection<T> = (
+  T extends any ? (x: T) => any : never
+) extends (x: infer R) => any
+  ? R
+  : never

--- a/nuxt/utils/validation.ts
+++ b/nuxt/utils/validation.ts
@@ -1,4 +1,5 @@
 import { helpers } from '@vuelidate/validators'
+import consola from 'consola'
 import { Ref } from 'vue'
 
 import {
@@ -8,7 +9,6 @@ import {
   REGEX_URL_HTTPS,
   REGEX_UUID,
 } from './constants'
-import { ApiData } from './util'
 
 import ACCOUNT_IS_EXISTING_QUERY from '~/gql/query/account/accountIsExisting.gql'
 import EVENT_IS_EXISTING_QUERY from '~/gql/query/event/eventIsExisting.gql'
@@ -31,22 +31,23 @@ export const VALIDATION_LAST_NAME_LENGTH_MAXIMUM = 100
 export const VALIDATION_PASSWORD_LENGTH_MINIMUM = 8
 export const VALIDATION_USERNAME_LENGTH_MAXIMUM = 100
 
-export async function formPreSubmit(
-  api: ApiData,
-  v$: any,
+export async function isFormValid({
+  v$,
+  isFormSent,
+}: {
+  v$: any
   isFormSent: Ref<boolean>
-): Promise<boolean> {
-  api.value.errors = []
+}): Promise<boolean> {
   v$.value.$touch()
 
-  const isFormValid = await v$.value.$validate()
-  isFormSent.value = isFormValid
+  const isValid = await v$.value.$validate()
+  isFormSent.value = isValid
 
-  if (!isFormValid) {
-    throw new Error('Form is invalid!')
+  if (!isValid) {
+    consola.error('Form in invalid!')
   }
 
-  return isFormValid
+  return isValid
 }
 
 export function validateEventSlug(


### PR DESCRIPTION
- move query and mutation definitions to `// api data`, dropping `// queries`
- greatly simplify `getApiData`, which not adds an error logger automatically
- remove `util` imports in favor of their auto-imports
- simplify `formPreSubmit` to `isFormValid`

Resolves #961