### PR TITLE
docs(readme): add a license scan badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/maevsi/maevsi/actions/workflows/docker.yml/badge.svg)](https://github.com/maevsi/maevsi/actions/workflows/docker.yml)
-
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmaevsi%2Fmaevsi.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fmaevsi%2Fmaevsi?ref=badge_shield)
 
 # maevsi
 


### PR DESCRIPTION
FOSSA now checks all licenses, e.g. of dependencies, for issues.