### PR TITLE
ci(docker): use v3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,10 +9,12 @@ on:
 jobs:
   build:
     name: Build
-    uses: dargmuesli/github-actions/.github/workflows/docker.yml@0.28.3
+    uses: dargmuesli/github-actions/.github/workflows/docker3.yml@0.28.3
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       DOCKER_HUB_USER_NAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
+    with:
+      ARTIFACT_PATH: .output/public
   release-semantic:
     needs: build
     name: Release (semantic)
@@ -21,7 +23,3 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       CACHE_PATH: nuxt/pnpm-lock.yaml
-  release-assets:
-    needs: release-semantic
-    name: Release (assets)
-    uses: dargmuesli/github-actions/.github/workflows/release-assets.yml@0.28.3


### PR DESCRIPTION
This action now uses official GitHub actions for Docker under the hood instead of a selfmade script: https://github.com/dargmuesli/github-actions/blob/d6b6c8baeeb9b3754d86d8eb94ff65b59e876a86/.github/workflows/docker3.yml
Also, the addition of build output zip files to GitHub releases is removed, because I don't see it being useful currently.