### PR TITLE
chore(vscode): use generally available graphql extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,5 +7,8 @@
     "graphql.vscode-graphql",
     "timonwong.shellcheck",
     "vue.volar",
+  ],
+  "unwantedRecommendations": [
+    "vscode.typescript-language-features"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,10 @@
 {
   "recommendations": [
-    "apollographql.vscode-apollo",
     "bradlc.vscode-tailwindcss",
     "dbaeumer.vscode-eslint",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
+    "graphql.vscode-graphql",
     "timonwong.shellcheck",
     "vue.volar",
   ]


### PR DESCRIPTION
We don't use Apollo GraphQL anymore and their extension is not available on the [Open VSX Registry](https://open-vsx.org/), so we can replace it with the generally available GraphQL extension.