### PR TITLE
chore(vscode): remove eslint configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "eslint.workingDirectories": [
-        { "directory": "./nuxt", "changeProcessCWD": true }
-    ],
-}


### PR DESCRIPTION
Does not seem to be required anymore, most likely due to better typescript interpretation by [Volar instead of Vetur](https://github.com/johnsoncodehk/volar/discussions/583).