### PR TITLE
chore(types): remove vue shim

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -56,7 +56,6 @@ export default defineNuxtConfig({
     },
   },
   typescript: {
-    shim: false,
     strict: true,
     tsConfig: {
       compilerOptions: {

--- a/nuxt/types/modules/vue.d.ts
+++ b/nuxt/types/modules/vue.d.ts
@@ -1,4 +1,0 @@
-declare module '*.vue' {
-  const content: any
-  export default content
-}


### PR DESCRIPTION
Does not seem to be required anymore, most likely due to better typescript interpretation by [Volar instead of Vetur](https://github.com/johnsoncodehk/volar/discussions/583).