### PR TITLE
chore(vscode): readd eslint configuration with added explanation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "eslint.workingDirectories": [
+        {
+            "directory": "nuxt" // needed to correctly lint global locale strings like `t('globalShowMore')`
+        }
+    ]
+}


### PR DESCRIPTION
Reverts #1069 as accounted for by adding an explanation that prevents a future erroneous deletion.
GitHub displays jsonc comments in their file preview with a red background color, but the comment seems to not interfere with functionality in vscode.