### PR TITLE
ci(release-schedule): set random cron day

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -2,7 +2,7 @@ name: 'Release: Scheduled'
 
 on:
   schedule:
-    - cron: '0 0 * * 1' # Every Monday at 00:00 AM UTC on the default branch
+    - cron: '0 0 * * 6' # Every Saturday at 00:00 AM UTC on the default branch
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
It's good practice to let cronjobs run at random times to not have all jobs being triggered at once. This PR sets the cronjob for automatic releases to run on Saturday instead of Monday.