### PR TITLE
feat(cookie-control): set links and shorten ids

### DIFF
--- a/nuxt/app.vue
+++ b/nuxt/app.vue
@@ -47,10 +47,8 @@ watch(
   () => cookieControl.cookiesEnabledIds.value,
   (current, previous) => {
     if (
-      (!previous?.includes('google-analytics') &&
-        current?.includes('google-analytics')) ||
-      (previous?.includes('google-analytics') &&
-        !current?.includes('google-analytics'))
+      (!previous?.includes('ga') && current?.includes('ga')) ||
+      (previous?.includes('ga') && !current?.includes('ga'))
     ) {
       window.location.reload()
     }

--- a/nuxt/cypress/e2e/event.cy.ts
+++ b/nuxt/cypress/e2e/event.cy.ts
@@ -11,7 +11,7 @@ describe('event page', () => {
   // TODO: mock data
   // context('visual regression', () => {
   //   it('looks as before', () => {
-  //     cy.setCookie('cookie_control_is_consent_given', 'true')
+  //     cy.setCookie('ncc_c', 'acltga')
   //     cy.visit('/event')
   //     cy.get('[data-is-loading="false"]').should('be.visible')
   //     cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/cypress/e2e/index.cy.ts
+++ b/nuxt/cypress/e2e/index.cy.ts
@@ -1,6 +1,6 @@
 describe('index page', () => {
   beforeEach(() => {
-    cy.setCookie('cookie_control_is_consent_given', 'true')
+    cy.setCookie('ncc_c', 'acltga')
   })
 
   context('page load', () => {
@@ -57,7 +57,7 @@ describe('index page', () => {
     })
 
     it('displays the cookie banner', () => {
-      cy.clearCookie('cookie_control_is_consent_given')
+      cy.clearCookie('ncc_c')
       cy.visit('/')
       cy.get('[data-is-loading="false"]').should('be.visible')
       cy.compareSnapshot('index_banner')

--- a/nuxt/cypress/e2e/legalnotice.cy.ts
+++ b/nuxt/cypress/e2e/legalnotice.cy.ts
@@ -10,7 +10,7 @@ describe('legal-notice page', () => {
 
   context('visual regression', () => {
     it('looks as before', () => {
-      cy.setCookie('cookie_control_is_consent_given', 'true')
+      cy.setCookie('ncc_c', 'acltga')
       cy.visit('/legal-notice')
       cy.get('[data-is-loading="false"]').should('be.visible')
       cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/cypress/e2e/privacypolicy.cy.ts
+++ b/nuxt/cypress/e2e/privacypolicy.cy.ts
@@ -10,7 +10,7 @@ describe('privacy-policy page', () => {
 
   context('visual regression', () => {
     it('looks as before', () => {
-      cy.setCookie('cookie_control_is_consent_given', 'true')
+      cy.setCookie('ncc_c', 'acltga')
       cy.visit('/privacy-policy')
       cy.get('[data-is-loading="false"]').should('be.visible')
       cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/cypress/e2e/taskAccountPasswordResetRequest.cy.ts
+++ b/nuxt/cypress/e2e/taskAccountPasswordResetRequest.cy.ts
@@ -10,7 +10,7 @@ describe('task account password reset request page', () => {
 
   context('visual regression', () => {
     it('looks as before', () => {
-      cy.setCookie('cookie_control_is_consent_given', 'true')
+      cy.setCookie('ncc_c', 'acltga')
       cy.visit('/task/account/password/reset/request')
       cy.get('[data-is-loading="false"]').should('be.visible')
       cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/cypress/e2e/taskAccountRegister.cy.ts
+++ b/nuxt/cypress/e2e/taskAccountRegister.cy.ts
@@ -11,7 +11,7 @@ describe('task account register page', () => {
   // TODO: find out why vuelidate thinks its pending while page load (maybe: https://github.com/maevsi/maevsi/issues/900)
   // context('visual regression', () => {
   //   it('looks as before', () => {
-  //     cy.setCookie('cookie_control_is_consent_given', 'true')
+  //     cy.setCookie('ncc_c', 'acltga')
   //     cy.visit('/task/account/register')
   //     cy.get('[data-is-loading="false"]').should('be.visible')
   //     cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/cypress/e2e/taskAccountSignIn.cy.ts
+++ b/nuxt/cypress/e2e/taskAccountSignIn.cy.ts
@@ -47,7 +47,7 @@ describe('task account sign-in page', () => {
 
   context('visual regression', () => {
     it('looks as before', () => {
-      cy.setCookie('cookie_control_is_consent_given', 'true')
+      cy.setCookie('ncc_c', 'acltga')
       cy.visit('/task/account/sign-in')
       cy.get('[data-is-loading="false"]').should('be.visible')
       cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/cypress/e2e/taskEventUnlock.cy.ts
+++ b/nuxt/cypress/e2e/taskEventUnlock.cy.ts
@@ -10,7 +10,7 @@ describe('task event unlock page', () => {
 
   context('visual regression', () => {
     it('looks as before', () => {
-      cy.setCookie('cookie_control_is_consent_given', 'true')
+      cy.setCookie('ncc_c', 'acltga')
       cy.visit('/task/event/unlock')
       cy.get('[data-is-loading="false"]').should('be.visible')
       cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/cypress/e2e/taskSearch.cy.ts
+++ b/nuxt/cypress/e2e/taskSearch.cy.ts
@@ -10,7 +10,7 @@ describe('task search page', () => {
 
   context('visual regression', () => {
     it('looks as before', () => {
-      cy.setCookie('cookie_control_is_consent_given', 'true')
+      cy.setCookie('ncc_c', 'acltga')
       cy.visit('/task/search')
       cy.get('[data-is-loading="false"]').should('be.visible')
       cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/cypress/e2e/teapot.cy.ts
+++ b/nuxt/cypress/e2e/teapot.cy.ts
@@ -13,7 +13,7 @@ describe('teapot page', () => {
 
   context('visual regression', () => {
     it('looks as before', () => {
-      cy.setCookie('cookie_control_is_consent_given', 'true')
+      cy.setCookie('ncc_c', 'acltga')
       cy.visit({ url: '/teapot', failOnStatusCode: false })
       cy.get('[data-is-loading="false"]').should('be.visible')
       cy.get('[data-testid="nuxt-cookie-control-control-button"]').should(

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -115,10 +115,7 @@ export default defineNuxtConfig({
             de: 'Cookie-Präferenzen',
             en: 'Cookie Preferences',
           },
-          targetCookieIds: [
-            'cookie_control_is_consent_given',
-            'cookie_control_cookies_enabled_ids',
-          ],
+          targetCookieIds: ['ncc_c', 'ncc_e'],
         },
         {
           description: {

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -98,6 +98,7 @@ export default defineNuxtConfig({
             de: 'Dieser Cookie von uns speichert Berechtigungen für den Datenbankzugriff dieser Webseite.',
             en: "This cookie of ours stores permissions for this website's database access.",
           },
+          id: 'a',
           name: {
             de: 'Authentifizierungsdaten',
             en: 'Authentication Data',
@@ -109,6 +110,7 @@ export default defineNuxtConfig({
             de: 'Dieser Cookie von uns speichert die Einstellungen, die in diesem Dialog getroffen werden.',
             en: 'This cookie of ours stores the settings made in this dialog.',
           },
+          id: 'c',
           name: {
             de: 'Cookie-Präferenzen',
             en: 'Cookie Preferences',
@@ -123,6 +125,7 @@ export default defineNuxtConfig({
             de: 'Dieser Cookie von uns speichert die Sprache, in der diese Webseite angezeigt wird.',
             en: "This cookie of ours stores the language that's used to display this website.",
           },
+          id: 'l',
           name: {
             de: 'Sprache',
             en: 'Language',
@@ -134,6 +137,7 @@ export default defineNuxtConfig({
             de: 'Dieser Cookie von uns speichert die Zeitzone, in der sich das Gerät zu befinden scheint.',
             en: 'This cookie of ours saves the timezone in which the device appears to be located.',
           },
+          id: 't',
           name: {
             de: 'Zeitzone',
             en: 'Timezone',
@@ -147,7 +151,12 @@ export default defineNuxtConfig({
             de: 'Die Cookies vom Drittanbieter Google ermöglichen die Analyse von Nutzerverhalten. Diese Analyse hilft uns unsere Dienste zu verbessern, indem wir verstehen, wie diese Webseite genutzt wird.',
             en: 'The third-party cookies by Google enable the analysis of user behavior. This analysis helps us to improve our services by understanding how this website is used.',
           },
-          id: 'google-analytics',
+          id: 'ga',
+          links: {
+            'https://policies.google.com/privacy': 'Google Privacy Policy',
+            'https://policies.google.com/terms?hl=en':
+              'Google Terms of Service',
+          },
           name: 'Analytics',
           targetCookieIds: [
             '_ga',

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -151,8 +151,7 @@ export default defineNuxtConfig({
           id: 'ga',
           links: {
             'https://policies.google.com/privacy': 'Google Privacy Policy',
-            'https://policies.google.com/terms?hl=en':
-              'Google Terms of Service',
+            'https://policies.google.com/terms': 'Google Terms of Service',
           },
           name: 'Analytics',
           targetCookieIds: [

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.21.0",
-    "@dargmuesli/nuxt-cookie-control": "5.0.0-beta.2",
+    "@dargmuesli/nuxt-cookie-control": "5.0.0-beta.7",
     "@funken-studio/sitemap-nuxt-3": "4.0.4",
     "@graphql-codegen/cli": "3.2.1",
     "@graphql-codegen/typescript": "3.0.1",

--- a/nuxt/plugins/gtag.client.ts
+++ b/nuxt/plugins/gtag.client.ts
@@ -8,8 +8,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(
     VueGtag,
     {
-      bootstrap:
-        !!cookieControl.cookiesEnabledIds.value?.includes('google-analytics'),
+      bootstrap: !!cookieControl.cookiesEnabledIds.value?.includes('ga'),
       config: {
         id: config.public.googleAnalyticsId,
       },

--- a/nuxt/pnpm-lock.yaml
+++ b/nuxt/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@babel/core': 7.21.0
-  '@dargmuesli/nuxt-cookie-control': 5.0.0-beta.2
+  '@dargmuesli/nuxt-cookie-control': 5.0.0-beta.7
   '@funken-studio/sitemap-nuxt-3': 4.0.4
   '@graphql-codegen/cli': 3.2.1
   '@graphql-codegen/typescript': 3.0.1
@@ -123,7 +123,7 @@ specifiers:
 
 devDependencies:
   '@babel/core': 7.21.0
-  '@dargmuesli/nuxt-cookie-control': 5.0.0-beta.2_rollup@3.17.3
+  '@dargmuesli/nuxt-cookie-control': 5.0.0-beta.7_rollup@3.17.3
   '@funken-studio/sitemap-nuxt-3': 4.0.4_rollup@3.17.3
   '@graphql-codegen/cli': 3.2.1_ki2loghmjmvginjtvfh464ve5i
   '@graphql-codegen/typescript': 3.0.1_graphql@16.6.0
@@ -230,7 +230,7 @@ devDependencies:
   stylelint-config-standard: 30.0.1_stylelint@15.2.0
   stylelint-no-unsupported-browser-features: 6.1.0_stylelint@15.2.0
   sweetalert2: 11.7.2
-  tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+  tailwindcss: 3.2.7_ts-node@10.9.1
   ts-jest: 29.0.5_3xvyzjgjzrgirji26c7yuhnryu
   ts-node: 10.9.1_ellgaeuoqnti3hful2ny2iugba
   typescript: 4.9.5
@@ -1072,11 +1072,11 @@ packages:
       - supports-color
     dev: true
 
-  /@dargmuesli/nuxt-cookie-control/5.0.0-beta.2_rollup@3.17.3:
-    resolution: {integrity: sha512-9GLiyetW2R2gdSEGYTpfel5Zq6QQeRaiNpQ5VLlOD1Zb6gm72f05Gy2KTNcJHL8j9xofnWIw3+zGkvIQD3hLpQ==}
+  /@dargmuesli/nuxt-cookie-control/5.0.0-beta.7_rollup@3.17.3:
+    resolution: {integrity: sha512-MYuaK+k4A197yaPfwsFks905tOUFBqsIk6ZJVQVhXgiuK/Q7oDRmcdFyU9cAYXjqLKmSIrGpgduDFLAozPg+Rg==}
     dependencies:
-      '@nuxt/kit': 3.1.1_rollup@3.17.3
-      '@sindresorhus/slugify': 2.1.1
+      '@nuxt/kit': 3.2.2_rollup@3.17.3
+      '@sindresorhus/slugify': 2.2.0
       css-vars-ponyfill: 2.4.8
       js-cookie: 3.0.1
       string-replace-loader: 3.1.0
@@ -2656,13 +2656,6 @@ packages:
       jest-mock: 29.4.3
     dev: true
 
-  /@jest/expect-utils/29.4.2:
-    resolution: {integrity: sha512-Dd3ilDJpBnqa0GiPN7QrudVs0cczMMHtehSo2CSTjm3zdHx0RcpmhFNVEltuEFeqfLIyWKFI224FsMSQ/nsJQA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      jest-get-type: 29.4.3
-    dev: true
-
   /@jest/expect-utils/29.4.3:
     resolution: {integrity: sha512-/6JWbkxHOP8EoS8jeeTd9dTfc9Uawi+43oLKHfp6zzux3U2hqOOVnV3ai4RpDYHOccL6g+5nrxpoc8DmJxtXVQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2736,7 +2729,7 @@ packages:
       slash: 3.0.0
       string-length: 4.0.2
       strip-ansi: 6.0.1
-      v8-to-istanbul: 9.0.1
+      v8-to-istanbul: 9.1.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2745,7 +2738,7 @@ packages:
     resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@sinclair/typebox': 0.25.21
+      '@sinclair/typebox': 0.25.24
     dev: true
 
   /@jest/source-map/29.4.3:
@@ -2938,33 +2931,6 @@ packages:
     resolution: {integrity: sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==}
     dev: true
 
-  /@nuxt/kit/3.1.1_rollup@3.17.3:
-    resolution: {integrity: sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==}
-    engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
-    dependencies:
-      '@nuxt/schema': 3.1.1_rollup@3.17.3
-      c12: 1.1.0
-      consola: 2.15.3
-      defu: 6.1.2
-      globby: 13.1.3
-      hash-sum: 2.0.0
-      ignore: 5.2.4
-      jiti: 1.17.0
-      knitwork: 1.0.0
-      lodash.template: 4.5.0
-      mlly: 1.1.0
-      pathe: 1.1.0
-      pkg-types: 1.0.1
-      scule: 1.0.0
-      semver: 7.3.8
-      unctx: 2.1.2
-      unimport: 2.2.4_rollup@3.17.3
-      untyped: 1.2.2
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: true
-
   /@nuxt/kit/3.2.0_rollup@3.17.3:
     resolution: {integrity: sha512-Otb1S/08tDxbpeQYLMynjr2TX7ssU1ynbWDpVzFzLBdfHkGWHXpIhJr+0u3LdnPUBw6C/xPXe7fd7RuXI9avoA==}
     engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
@@ -3012,28 +2978,6 @@ packages:
       scule: 1.0.0
       semver: 7.3.8
       unctx: 2.1.2
-      unimport: 2.2.4_rollup@3.17.3
-      untyped: 1.2.2
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: true
-
-  /@nuxt/schema/3.1.1_rollup@3.17.3:
-    resolution: {integrity: sha512-/KuoCDVGrLD9W7vwuYhu4HbdT/BpbrhA4Pm9dGn7Jah40kHDGqUnJxugvMjt+4suq53rLQyTA0LRDWfFxfxAOQ==}
-    engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
-    dependencies:
-      c12: 1.1.2
-      create-require: 1.1.1
-      defu: 6.1.2
-      hookable: 5.4.2
-      jiti: 1.17.1
-      pathe: 1.1.0
-      pkg-types: 1.0.2
-      postcss-import-resolver: 2.0.0
-      scule: 1.0.0
-      std-env: 3.3.2
-      ufo: 1.1.0
       unimport: 2.2.4_rollup@3.17.3
       untyped: 1.2.2
     transitivePeerDependencies:
@@ -3579,12 +3523,12 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@sinclair/typebox/0.25.21:
-    resolution: {integrity: sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==}
+  /@sinclair/typebox/0.25.24:
+    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
     dev: true
 
-  /@sindresorhus/slugify/2.1.1:
-    resolution: {integrity: sha512-XokPHZ+q6FtQGEi1hnfvARVJJVPEhwHQTPHPPuNHaN6zcHjzYNynhhHMopa1wNPqLAFOwpsbintunEqWecXJMg==}
+  /@sindresorhus/slugify/2.2.0:
+    resolution: {integrity: sha512-9Vybc/qX8Kj6pxJaapjkFbiUJPk7MAkCh/GFCxIBnnsuYCFPIXKvnLidG8xlepht3i24L5XemUmGtrJ3UWrl6w==}
     engines: {node: '>=12'}
     dependencies:
       '@sindresorhus/transliterate': 1.6.0
@@ -3616,7 +3560,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+      tailwindcss: 3.2.7_ts-node@10.9.1
     dev: true
 
   /@tailwindcss/line-clamp/0.4.2_tailwindcss@3.2.7:
@@ -3624,7 +3568,7 @@ packages:
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
-      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+      tailwindcss: 3.2.7_ts-node@10.9.1
     dev: true
 
   /@tailwindcss/typography/0.5.9_tailwindcss@3.2.7:
@@ -3636,7 +3580,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+      tailwindcss: 3.2.7_ts-node@10.9.1
     dev: true
 
   /@tiptap/core/2.0.0-beta.218_@tiptap+pm@2.0.0-beta.218:
@@ -4007,8 +3951,8 @@ packages:
   /@types/jest/29.4.0:
     resolution: {integrity: sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==}
     dependencies:
-      expect: 29.4.2
-      pretty-format: 29.4.2
+      expect: 29.4.3
+      pretty-format: 29.4.3
     dev: true
 
   /@types/js-yaml/4.0.5:
@@ -5378,21 +5322,6 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
-    dev: true
-
-  /c12/1.1.0:
-    resolution: {integrity: sha512-9KRFWEng+TH8sGST4NNdiKzZGw1Z1CHnPGAmNqAyVP7suluROmBjD8hsiR34f94DdlrvtGvvmiGDsoFXlCBWIw==}
-    dependencies:
-      defu: 6.1.2
-      dotenv: 16.0.3
-      giget: 1.1.2
-      jiti: 1.17.1
-      mlly: 1.1.1
-      pathe: 1.1.0
-      pkg-types: 1.0.2
-      rc9: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /c12/1.1.2:
@@ -7471,17 +7400,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /expect/29.4.2:
-    resolution: {integrity: sha512-+JHYg9O3hd3RlICG90OPVjRkPBoiUH7PxvDVMnRiaq1g6JUgZStX514erMl0v2Dc5SkfVbm7ztqbd6qHHPn+mQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/expect-utils': 29.4.2
-      jest-get-type: 29.4.2
-      jest-matcher-utils: 29.4.2
-      jest-message-util: 29.4.2
-      jest-util: 29.4.2
-    dev: true
-
   /expect/29.4.3:
     resolution: {integrity: sha512-uC05+Q7eXECFpgDrHdXA4k2rpMyStAYPItEDLyQDo5Ta7fVkJnNA/4zh/OIVkVVNZ1oOK1PipQoyNjuZ6sz6Dg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7700,16 +7618,6 @@ packages:
 
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
-    dev: true
-
-  /follow-redirects/1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
     dev: true
 
   /follow-redirects/1.15.2_debug@4.3.4:
@@ -8387,7 +8295,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -9216,11 +9124,6 @@ packages:
       jest-util: 29.4.3
     dev: true
 
-  /jest-get-type/29.4.2:
-    resolution: {integrity: sha512-vERN30V5i2N6lqlFu4ljdTqQAgrkTFMC9xaIIfOPYBw04pufjXRty5RuXBiB1d72tGbURa/UgoiHB90ruOSivg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
-
   /jest-get-type/29.4.3:
     resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -9253,16 +9156,6 @@ packages:
       pretty-format: 29.4.3
     dev: true
 
-  /jest-matcher-utils/29.4.2:
-    resolution: {integrity: sha512-EZaAQy2je6Uqkrm6frnxBIdaWtSYFoR8SVb2sNLAtldswlR/29JAgx+hy67llT3+hXBaLB0zAm5UfeqerioZyg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 29.4.3
-      jest-get-type: 29.4.3
-      pretty-format: 29.4.3
-    dev: true
-
   /jest-matcher-utils/29.4.3:
     resolution: {integrity: sha512-TTciiXEONycZ03h6R6pYiZlSkvYgT0l8aa49z/DLSGYjex4orMUcafuLXYyyEDWB1RKglq00jzwY00Ei7yFNVg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -9271,21 +9164,6 @@ packages:
       jest-diff: 29.4.3
       jest-get-type: 29.4.3
       pretty-format: 29.4.3
-    dev: true
-
-  /jest-message-util/29.4.2:
-    resolution: {integrity: sha512-SElcuN4s6PNKpOEtTInjOAA8QvItu0iugkXqhYyguRvQoXapg5gN+9RQxLAkakChZA7Y26j6yUCsFWN+hlKD6g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@jest/types': 29.4.3
-      '@types/stack-utils': 2.0.1
-      chalk: 4.1.2
-      graceful-fs: 4.2.10
-      micromatch: 4.0.5
-      pretty-format: 29.4.3
-      slash: 3.0.0
-      stack-utils: 2.0.6
     dev: true
 
   /jest-message-util/29.4.3:
@@ -9445,18 +9323,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-util/29.4.2:
-    resolution: {integrity: sha512-wKnm6XpJgzMUSRFB7YF48CuwdzuDIHenVuoIb1PLuJ6F+uErZsuDkU+EiExkChf6473XcawBrSfDSnXl+/YG4g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/types': 29.4.3
-      '@types/node': 18.14.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      graceful-fs: 4.2.10
-      picomatch: 2.3.1
-    dev: true
-
   /jest-util/29.4.3:
     resolution: {integrity: sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -9523,11 +9389,6 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
-    dev: true
-
-  /jiti/1.17.0:
-    resolution: {integrity: sha512-CByzPgFqYoB9odEeef7GNmQ3S5THIBOtzRYoSCya2Sv27AuQxy2jgoFjQ6VTF53xsq1MXRm+YWNvOoDHUAteOw==}
-    hasBin: true
     dev: true
 
   /jiti/1.17.1:
@@ -10459,15 +10320,6 @@ packages:
     hasBin: true
     dev: true
 
-  /mlly/1.1.0:
-    resolution: {integrity: sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==}
-    dependencies:
-      acorn: 8.8.2
-      pathe: 1.1.0
-      pkg-types: 1.0.2
-      ufo: 1.1.0
-    dev: true
-
   /mlly/1.1.1:
     resolution: {integrity: sha512-Jnlh4W/aI4GySPo6+DyTN17Q75KKbLTyFK8BrGhjNP4rxuUjbRWhE6gHg3bs33URWAF44FRm7gdQA348i3XxRw==}
     dependencies:
@@ -11341,14 +11193,6 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /pkg-types/1.0.1:
-    resolution: {integrity: sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==}
-    dependencies:
-      jsonc-parser: 3.2.0
-      mlly: 1.1.1
-      pathe: 1.1.0
-    dev: true
-
   /pkg-types/1.0.2:
     resolution: {integrity: sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==}
     dependencies:
@@ -11917,15 +11761,6 @@ packages:
   /pretty-bytes/6.1.0:
     resolution: {integrity: sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
-    dev: true
-
-  /pretty-format/29.4.2:
-    resolution: {integrity: sha512-qKlHR8yFVCbcEWba0H0TOC8dnLlO4vPlyEjRPw31FZ2Rupy9nLa8ZLbYny8gWEl8CkEhJqAE6IzdNELTBVcBEg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.4.3
-      ansi-styles: 5.2.0
-      react-is: 18.2.0
     dev: true
 
   /pretty-format/29.4.3:
@@ -13317,12 +13152,10 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwindcss/3.2.7_aesdjsunmf4wiehhujt67my7tu:
+  /tailwindcss/3.2.7_ts-node@10.9.1:
     resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -13576,7 +13409,7 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.4.3_jboh4c3iv3wxuja4m36ecyac7e
-      jest-util: 29.4.2
+      jest-util: 29.4.3
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -13972,8 +13805,8 @@ packages:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: true
 
-  /v8-to-istanbul/9.0.1:
-    resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
+  /v8-to-istanbul/9.1.0:
+    resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
     engines: {node: '>=10.12.0'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17


### PR DESCRIPTION
I've [put some work into the cookie module](https://github.com/dargmuesli/nuxt-cookie-control/pull/42/files) so we can now add links e.g. to Privacy Policies of third party cookie providers. It's also a good idea to use (short) cookie ids to save bandwidth.