### PR TITLE
chore(stylelint): remove prettier configuration

### DIFF
--- a/nuxt/.stylelintrc
+++ b/nuxt/.stylelintrc
@@ -1,7 +1,6 @@
 {
   "extends": [
     "stylelint-config-standard",
-    "stylelint-config-prettier",
     "stylelint-config-recommended-vue"
   ],
   "plugins": ["stylelint-no-unsupported-browser-features"],

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -138,7 +138,6 @@
     "slugify": "1.6.5",
     "start-server-and-test": "1.15.4",
     "stylelint": "15.2.0",
-    "stylelint-config-prettier": "9.0.5",
     "stylelint-config-recommended-vue": "1.4.0",
     "stylelint-config-standard": "30.0.1",
     "stylelint-no-unsupported-browser-features": "6.1.0",

--- a/nuxt/pnpm-lock.yaml
+++ b/nuxt/pnpm-lock.yaml
@@ -104,7 +104,6 @@ specifiers:
   slugify: 1.6.5
   start-server-and-test: 1.15.4
   stylelint: 15.2.0
-  stylelint-config-prettier: 9.0.5
   stylelint-config-recommended-vue: 1.4.0
   stylelint-config-standard: 30.0.1
   stylelint-no-unsupported-browser-features: 6.1.0
@@ -225,12 +224,11 @@ devDependencies:
   slugify: 1.6.5
   start-server-and-test: 1.15.4
   stylelint: 15.2.0
-  stylelint-config-prettier: 9.0.5_stylelint@15.2.0
   stylelint-config-recommended-vue: 1.4.0_x2qzl5lwlwnkkekx7bj2y4o6y4
   stylelint-config-standard: 30.0.1_stylelint@15.2.0
   stylelint-no-unsupported-browser-features: 6.1.0_stylelint@15.2.0
   sweetalert2: 11.7.2
-  tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+  tailwindcss: 3.2.7_ts-node@10.9.1
   ts-jest: 29.0.5_3xvyzjgjzrgirji26c7yuhnryu
   ts-node: 10.9.1_uayvamxqnl5yeiojjysxwopmsy
   typescript: 4.9.5
@@ -3594,7 +3592,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+      tailwindcss: 3.2.7_ts-node@10.9.1
     dev: true
 
   /@tailwindcss/line-clamp/0.4.2_tailwindcss@3.2.7:
@@ -3602,7 +3600,7 @@ packages:
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
-      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+      tailwindcss: 3.2.7_ts-node@10.9.1
     dev: true
 
   /@tailwindcss/typography/0.5.9_tailwindcss@3.2.7:
@@ -3614,7 +3612,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+      tailwindcss: 3.2.7_ts-node@10.9.1
     dev: true
 
   /@tiptap/core/2.0.0-beta.218_@tiptap+pm@2.0.0-beta.218:
@@ -13088,16 +13086,6 @@ packages:
       stylelint: 15.2.0
     dev: true
 
-  /stylelint-config-prettier/9.0.5_stylelint@15.2.0:
-    resolution: {integrity: sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==}
-    engines: {node: '>= 12'}
-    hasBin: true
-    peerDependencies:
-      stylelint: '>= 11.x < 15'
-    dependencies:
-      stylelint: 15.2.0
-    dev: true
-
   /stylelint-config-recommended-vue/1.4.0_x2qzl5lwlwnkkekx7bj2y4o6y4:
     resolution: {integrity: sha512-DVJqyX2KvMCn9U0+keL12r7xlsH26K4Vg8NrIZuq5MoF7g82DpMp326Om4E0Q+Il1o+bTHuUyejf2XAI0iD04Q==}
     engines: {node: ^12 || >=14}
@@ -13277,12 +13265,10 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwindcss/3.2.7_aesdjsunmf4wiehhujt67my7tu:
+  /tailwindcss/3.2.7_ts-node@10.9.1:
     resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3


### PR DESCRIPTION
[Prettier v15 decided to stop feeling responsible for general code styling and now let's prettier itself do that job](https://stylelint.io/migration-guide/to-15/#deprecated-stylistic-rules), thus dropping own prettier configuration.