### PR TITLE
fix(docker): install dependencies in cypress stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,8 @@ ARG GID=1000
 
 WORKDIR /srv/app/
 
+COPY ./docker/entrypoint-dev.sh /usr/local/bin/
+
 RUN corepack enable \
     # user
     && groupadd -g $GID -o $UNAME \
@@ -122,7 +124,10 @@ COPY --from=prepare --chown=$UNAME /root/.cache/Cypress /root/.cache/Cypress
 
 USER $UNAME
 
+VOLUME /srv/.pnpm-store
 VOLUME /srv/app
+
+ENTRYPOINT ["entrypoint-dev.sh"]
 
 
 ########################

--- a/docker/entrypoint-dev.sh
+++ b/docker/entrypoint-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+pnpm config set store-dir /srv/.pnpm-store
+pnpm install
+
+exec "$@"

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -19,7 +19,7 @@
     "test:integration:dev": "cross-env NUXT_PUBLIC_IS_TESTING=1 WAIT_ON_TIMEOUT=100000 start-server-and-test 'pnpm dev' 'http://localhost:3000' 'pnpm cypress:test'",
     "test:integration:prod": "cross-env NUXT_PUBLIC_IS_TESTING=1 WAIT_ON_TIMEOUT=10000 NODE_ENV=production start-server-and-test 'pnpm start' 'http://localhost:3000' 'pnpm cypress:test'",
     "test:integration:docker:build": "docker build -t test-integration_base --build-arg UID=$(id -u) --build-arg GID=$(id -g) --target test-integration_base ../",
-    "test:integration:docker:run": "docker run --rm --entrypoint '' -v \"$PWD:/srv/app\" test-integration_base",
+    "test:integration:docker:run": "docker run --rm -v \"$PWD:/srv/app\" -v \"$(pnpm store path):/srv/.pnpm-store\" test-integration_base",
     "test:integration:docker:br": "pnpm test:integration:docker:build && pnpm test:integration:docker:run",
     "test:integration:docker:dev": "pnpm test:integration:docker:br pnpm test:integration:dev",
     "test:integration:docker:prod": "pnpm test:integration:docker:br pnpm test:integration:prod",


### PR DESCRIPTION
Adds an entrypoint script that installs dependencies from the perspective of the cypress stage.

@PatrickMi The `sharp` error on development should not occur from the looks of it, as the dependencies are installed by that stage already. I'd need to take a second look at your installation.