### PR TITLE
fix(tusd): workaround image url suffix

### DIFF
--- a/nuxt/components/_/ImageUploadGallery.vue
+++ b/nuxt/components/_/ImageUploadGallery.vue
@@ -269,7 +269,7 @@ const getMimeType = (file: ArrayBuffer, fallback?: string) => {
   }
 }
 const getUploadImageSrc = (uploadStorageKey: string) =>
-  TUSD_FILES_URL + uploadStorageKey + '+'
+  TUSD_FILES_URL + uploadStorageKey + '++'
 const loadProfilePicture = (event: Event) => {
   const target = event.target as HTMLInputElement
   const files = Array.from(target.files ?? [])

--- a/nuxt/components/_/ImageUploadGallery.vue
+++ b/nuxt/components/_/ImageUploadGallery.vue
@@ -269,7 +269,7 @@ const getMimeType = (file: ArrayBuffer, fallback?: string) => {
   }
 }
 const getUploadImageSrc = (uploadStorageKey: string) =>
-  TUSD_FILES_URL + uploadStorageKey + '++'
+  TUSD_FILES_URL + uploadStorageKey
 const loadProfilePicture = (event: Event) => {
   const target = event.target as HTMLInputElement
   const files = Array.from(target.files ?? [])

--- a/nuxt/components/account/AccountProfilePicture.vue
+++ b/nuxt/components/account/AccountProfilePicture.vue
@@ -44,7 +44,7 @@ const profilePicture = computed(
 )
 const profilePictureUrl = computed(() =>
   profilePicture?.value?.uploadStorageKey
-    ? TUSD_FILES_URL + profilePicture.value.uploadStorageKey + '++'
+    ? TUSD_FILES_URL + profilePicture.value.uploadStorageKey
     : undefined
 )
 </script>

--- a/nuxt/components/account/AccountProfilePicture.vue
+++ b/nuxt/components/account/AccountProfilePicture.vue
@@ -44,7 +44,7 @@ const profilePicture = computed(
 )
 const profilePictureUrl = computed(() =>
   profilePicture?.value?.uploadStorageKey
-    ? TUSD_FILES_URL + profilePicture.value.uploadStorageKey + '+'
+    ? TUSD_FILES_URL + profilePicture.value.uploadStorageKey + '++'
     : undefined
 )
 </script>

--- a/nuxt/server/api/tusd.ts
+++ b/nuxt/server/api/tusd.ts
@@ -156,12 +156,15 @@ async function tusdDelete(event: H3Event) {
   const storageKey = queryRes.rows[0] ? queryRes.rows[0].storage_key : null
 
   if (storageKey !== null) {
-    const httpResp = await fetch('http://tusd:1080/files/' + storageKey + '+', {
-      headers: {
-        'Tus-Resumable': '1.0.0',
-      },
-      method: 'DELETE',
-    })
+    const httpResp = await fetch(
+      'http://tusd:1080/files/' + storageKey + '++',
+      {
+        headers: {
+          'Tus-Resumable': '1.0.0',
+        },
+        method: 'DELETE',
+      }
+    )
 
     if (httpResp.ok) {
       if (httpResp.status === 204) {

--- a/nuxt/server/api/tusd.ts
+++ b/nuxt/server/api/tusd.ts
@@ -87,7 +87,9 @@ async function deleteUpload(event: H3Event, uploadId: any, storageKey: any) {
 }
 
 async function tusdDelete(event: H3Event) {
-  const { req } = event
+  const {
+    node: { req },
+  } = event
   const uploadId = getQuery(event).uploadId
 
   consola.log('tusdDelete: ' + uploadId)
@@ -156,15 +158,12 @@ async function tusdDelete(event: H3Event) {
   const storageKey = queryRes.rows[0] ? queryRes.rows[0].storage_key : null
 
   if (storageKey !== null) {
-    const httpResp = await fetch(
-      'http://tusd:1080/files/' + storageKey + '++',
-      {
-        headers: {
-          'Tus-Resumable': '1.0.0',
-        },
-        method: 'DELETE',
-      }
-    )
+    const httpResp = await fetch('http://tusd:1080/files/' + storageKey, {
+      headers: {
+        'Tus-Resumable': '1.0.0',
+      },
+      method: 'DELETE',
+    })
 
     if (httpResp.ok) {
       if (httpResp.status === 204) {
@@ -198,7 +197,9 @@ async function tusdDelete(event: H3Event) {
 }
 
 async function tusdPost(event: H3Event) {
-  const { req } = event
+  const {
+    node: { req },
+  } = event
   const body = await readBody(event)
 
   switch (req.headers['hook-name']) {
@@ -232,12 +233,12 @@ async function tusdPost(event: H3Event) {
 
       break
     }
-    case 'post-finish': {
-      consola.log('tusd/post-finish: ' + body.Upload.Storage.Key)
+    case 'pre-finish': {
+      consola.log('tusd/pre-finish: ' + body.Upload.ID)
 
       const queryRes = await pool
         .query('UPDATE maevsi.upload SET storage_key = $1 WHERE uuid = $2;', [
-          body.Upload.Storage.Key,
+          body.Upload.ID,
           body.Upload.MetaData.maevsiUploadUuid,
         ])
         .catch((err) => {
@@ -257,11 +258,11 @@ async function tusdPost(event: H3Event) {
       break
     }
     case 'post-terminate':
-      consola.log('tusd/post-terminate: ' + body.Upload.Storage.Key)
+      consola.log('tusd/post-terminate: ' + body.Upload.ID)
       await deleteUpload(
         event,
         body.Upload.MetaData.maevsiUploadUuid,
-        body.Upload.Storage.Key
+        body.Upload.ID
       )
 
       break


### PR DESCRIPTION
Resolves #1140

Unsure why image loading stopped working.
We currently only save the `uploadId` and not the multipart `uploadId`. Both ids are separated by a plus sign. Adding a character after the plus sign, like another one, seems to fill in the multipart `uploadId`, preventing an error. Again, I don't know why leaving the second id out ever worked.
We now use both ids.