### PR TITLE
chore(package): simplify prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   },
   "packageManager": "pnpm@8.1.0",
   "scripts": {
-    "prepare": "pnpm --dir nuxt install && if [ \"$NODE_ENV\" != \"production\" ]; then husky install && shx rm -rf .git/hooks && shx ln -s ../.husky .git/hooks; fi"
+    "prepare": "husky install && pnpm --dir nuxt install"
   },
   "devDependencies": {
     "@commitlint/cli": "17.5.1",
     "@commitlint/config-conventional": "17.4.4",
-    "husky": "8.0.3",
-    "shx": "0.3.4"
+    "husky": "8.0.3"
   }
 }


### PR DESCRIPTION
GitKraken now supports Git's `core.hooksPath` setting, so the custom prepare script is not needed anymore.