### PR TITLE
fix(docker): install curl for cypress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,9 +113,12 @@ WORKDIR /srv/app/
 COPY ./docker/entrypoint-dev.sh /usr/local/bin/
 
 RUN corepack enable \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        curl \
     # user
     && groupadd -g $GID -o $UNAME \
-    && useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+    && useradd -m -l -u $UID -g $GID -o -s /bin/bash $UNAME
 
 # Use the Cypress version installed by pnpm, not as provided by the Docker image.
 COPY --from=prepare --chown=$UNAME /root/.cache/Cypress /root/.cache/Cypress
@@ -134,7 +137,10 @@ ENTRYPOINT ["entrypoint-dev.sh"]
 # Should be the specific version of `cypress/included`.
 FROM cypress/included:12.9.0 AS test-integration-dev
 
-RUN corepack enable
+RUN corepack enable \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        curl
 
 WORKDIR /srv/app/
 
@@ -151,7 +157,10 @@ RUN pnpm test:integration:dev
 # Should be the specific version of `cypress/included`.
 FROM cypress/included:12.9.0 AS test-integration-prod
 
-RUN corepack enable
+RUN corepack enable \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        curl
 
 WORKDIR /srv/app/
 

--- a/nuxt/cypress.config.ts
+++ b/nuxt/cypress.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     video: false,
   },
   env: {
+    ALWAYS_GENERATE_DIFF: false,
     failSilently: false,
   },
   screenshotsFolder: './cypress/snapshots/actual',


### PR DESCRIPTION
Installs `curl` for Cypress Docker stages and configures Cypress so that only diffs are saved as images when a diff is detected.