### PR TITLE
fix(icon-container): use span for icons

### DIFF
--- a/nuxt/components/icon/IconContainerNew.vue
+++ b/nuxt/components/icon/IconContainerNew.vue
@@ -1,7 +1,7 @@
 <template>
-  <div :class="classes">
+  <span :class="classes">
     <slot />
-  </div>
+  </span>
 </template>
 
 <script setup lang="ts">
@@ -9,6 +9,6 @@ export interface Props {
   classes?: string
 }
 withDefaults(defineProps<Props>(), {
-  classes: 'h-5 md:h-6 w-5 md:w-6 shrink-0',
+  classes: 'h-5 md:h-6 w-5 md:w-6 shrink-0 block',
 })
 </script>

--- a/nuxt/components/icon/IconContainerNew.vue
+++ b/nuxt/components/icon/IconContainerNew.vue
@@ -8,7 +8,12 @@
 export interface Props {
   classes?: string
 }
-withDefaults(defineProps<Props>(), {
-  classes: 'h-5 md:h-6 w-5 md:w-6 shrink-0 block',
+const props = withDefaults(defineProps<Props>(), {
+  classes: 'h-5 md:h-6 w-5 md:w-6 shrink-0',
+})
+
+// computations
+const classes = computed(() => {
+  return ['block', props.classes].join(' ')
 })
 </script>


### PR DESCRIPTION
`div`s might not be allowed under `button`s, for example.
How to review:
- check the nuxt console after a page reload: it should not show `error  <div> element is not permitted as content under <span>  element-permitted-content` for example on the upload page
- see if any icons break; they should not