### PR TITLE
fix(image-upload-gallery): correct button trash margin

### DIFF
--- a/nuxt/components/_/ImageUploadGallery.vue
+++ b/nuxt/components/_/ImageUploadGallery.vue
@@ -33,21 +33,20 @@
               :title="t('uploadSize', { size: bytesToString(upload.sizeByte) })"
               width="128"
             />
-            <div v-if="allowDeletion">
-              <div
-                class="absolute right-0 top-0 rounded-bl-lg bg-red-600 bg-opacity-75"
-                @click="deleteImageUpload(upload.id)"
+            <div
+              v-if="allowDeletion"
+              class="absolute flex right-0 top-0 rounded-bl-lg bg-red-600 bg-opacity-75"
+              @click="deleteImageUpload(upload.id)"
+            >
+              <Button
+                :aria-label="t('iconTrashLabel')"
+                class="flex h-full justify-center"
               >
-                <Button
-                  :aria-label="t('iconTrashLabel')"
-                  class="flex h-full justify-center"
-                >
-                  <IconTrash
-                    class="m-1 text-text-bright"
-                    :title="t('iconTrash')"
-                  />
-                </Button>
-              </div>
+                <IconTrash
+                  class="m-1 text-text-bright"
+                  :title="t('iconTrash')"
+                />
+              </Button>
             </div>
           </li>
         </template>


### PR DESCRIPTION
Fix for the upload page. Previously: 
![image](https://user-images.githubusercontent.com/4778485/234671328-70393582-9d3b-49ee-8296-7d44e62c0bd0.png)
Now: 
![image](https://user-images.githubusercontent.com/4778485/234671366-689b3337-5830-49d3-8ff6-c46e133f24da.png)
The icon container is now square, which should be the case. It's the icon itself that does not have equal space around the x and y axis, but that's something for another ticket.