### PR TITLE
fix(sql): disallow deleting contact assigned to own account

### DIFF
--- a/sqitch/deploy/table_contact_policy.sql
+++ b/sqitch/deploy/table_contact_policy.sql
@@ -36,6 +36,8 @@ CREATE POLICY contact_update ON maevsi.contact FOR UPDATE USING (
 -- Only allow deletes for contacts authored by the invoker's account.
 CREATE POLICY contact_delete ON maevsi.contact FOR DELETE USING (
   author_account_username = current_setting('jwt.claims.username', true)::TEXT
+  AND
+  account_username != current_setting('jwt.claims.username', true)::TEXT
 );
 
 COMMIT;


### PR DESCRIPTION
You should not be able to delete the contact assigned to your account.