### PR TITLE
feat(contact): translate message for duplicate key violation

### DIFF
--- a/nuxt/components/form/FormContact.vue
+++ b/nuxt/components/form/FormContact.vue
@@ -2,6 +2,9 @@
   <Form
     class="min-h-0 flex flex-col"
     :errors="api.errors"
+    :errors-pg-ids="{
+      postgres23505: t('postgres23505'),
+    }"
     :form="v$"
     :is-form-sent="isFormSent"
     :submit-name="t('save')"
@@ -246,11 +249,13 @@ de:
   address: Adresse
   firstName: Vorname
   lastName: Nachname
+  postgres23505: Ein Kontakt mit dieser Nutzernamen existiert bereits!
   save: Speichern
 en:
   accountOverride: You can add an existing account as a contact or enter contact data manually. If both data are entered, the manually entered data will be used preferentially.
   address: Address
   firstName: First name
   lastName: Last name
+  postgres23505: A contact with this username already exists!
   save: Save
 </i18n>


### PR DESCRIPTION
Shows a user readable text instead of the English only database error message.