### PR TITLE
fix(menu): remove calendar icon

### DIFF
--- a/nuxt/components/layout/LayoutMenu.vue
+++ b/nuxt/components/layout/LayoutMenu.vue
@@ -19,7 +19,6 @@
             :to="localePath('/dashboard')"
             @click="emit('onMenuHide')"
           >
-            <IconCalendar />
             {{ t('dashboard') }}
           </ButtonColored>
         </div>


### PR DESCRIPTION
The button should have no icon, especially not the calendar icon. Seems to have been placed there by mistake.