### PR TITLE
ci: correct pull request check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: 'Build: frontend'
     uses: dargmuesli/github-actions/.github/workflows/docker-ghcr.yml@0.38.1
     needs: prepare_jobs
-    if: needs.prepare_jobs.outputs.pr == '' || github.event_name != 'push'
+    if: needs.prepare_jobs.outputs.pr_found != 'true' || github.event_name != 'push'
     permissions:
       packages: write
     with:
@@ -34,7 +34,7 @@ jobs:
     name: 'Build: database-migration'
     uses: dargmuesli/github-actions/.github/workflows/docker-ghcr.yml@0.38.1
     needs: prepare_jobs
-    if: needs.prepare_jobs.outputs.pr == '' || github.event_name != 'push'
+    if: needs.prepare_jobs.outputs.pr_found != 'true' || github.event_name != 'push'
     permissions:
       packages: write
     with:


### PR DESCRIPTION
`8BitJonny/gh-get-current-pr` has a `pr_found` output that`s `true` if a PR has been found, which should be used instead of checking for string emptyness on the JSON output.