### PR TITLE
refactor(nuxt): always use `ssrContext` to get request event

### DIFF
--- a/nuxt/composables/useDateTime.ts
+++ b/nuxt/composables/useDateTime.ts
@@ -1,11 +1,11 @@
 import { Dayjs } from 'dayjs'
 
 export const useDateTime = () => {
-  const event = useRequestEvent()
+  const { ssrContext } = useNuxtApp()
   const { $dayjs } = useNuxtApp()
   const timezoneCookie = useCookie(TIMEZONE_COOKIE_NAME)
 
-  const timezoneHeader = event?.node.req.headers[TIMEZONE_HEADER_KEY]
+  const timezoneHeader = ssrContext?.event.node.req.headers[TIMEZONE_HEADER_KEY]
   const timezone =
     timezoneHeader && !Array.isArray(timezoneHeader)
       ? timezoneHeader

--- a/nuxt/composables/useHost.ts
+++ b/nuxt/composables/useHost.ts
@@ -1,8 +1,8 @@
 export const useHost = () => {
-  if (process.server) {
-    const event = useRequestEvent()
+  const { ssrContext } = useNuxtApp()
 
-    return getHost(event)
+  if (ssrContext) {
+    return getHost(ssrContext.event)
   } else {
     return location.host
   }

--- a/nuxt/pages/teapot/index.vue
+++ b/nuxt/pages/teapot/index.vue
@@ -7,7 +7,7 @@
 definePageMeta({
   middleware: [
     defineNuxtRouteMiddleware(() => {
-      const { ssrContext } = useNuxtApp() // cannot use `useRequestEvent` instead
+      const { ssrContext } = useNuxtApp()
 
       if (ssrContext) {
         ssrContext.event.node.res.statusCode = 418

--- a/nuxt/utils/auth.ts
+++ b/nuxt/utils/auth.ts
@@ -132,15 +132,14 @@ export const jwtStore = async ({
 }
 
 export const useJwtStore = () => {
-  const { $urqlReset } = useNuxtApp()
+  const { $urqlReset, ssrContext } = useNuxtApp()
   const store = useMaevsiStore()
-  const event = useRequestEvent()
 
   return {
     async jwtStore(jwt?: string) {
       await jwtStore({
         $urqlReset,
-        event,
+        event: ssrContext?.event,
         jwt,
         store,
       })
@@ -164,9 +163,8 @@ export const signOut = async ({
 }
 
 export const useSignOut = () => {
-  const { $urql, $urqlReset } = useNuxtApp()
+  const { $urql, $urqlReset, ssrContext } = useNuxtApp()
   const store = useMaevsiStore()
-  const event = useRequestEvent()
 
   return {
     async signOut() {
@@ -174,7 +172,7 @@ export const useSignOut = () => {
         client: $urql.value,
         $urqlReset,
         store,
-        event,
+        event: ssrContext?.event,
       })
     },
   }


### PR DESCRIPTION
`ssrContext` can pretty much always be accessed whereas `useRequestEvent` cannot.