### PR TITLE
fix(sign-in): correct middleware route

### DIFF
--- a/nuxt/pages/task/account/sign-in.vue
+++ b/nuxt/pages/task/account/sign-in.vue
@@ -15,15 +15,15 @@ import { useMaevsiStore } from '~/store'
 
 definePageMeta({
   middleware: [
-    defineNuxtRouteMiddleware(() => {
+    defineNuxtRouteMiddleware((to) => {
       const store = useMaevsiStore()
       const localePath = useLocalePath()
 
       if (
         store.jwtDecoded?.role === 'maevsi_account' &&
-        !Array.isArray(route.query.referrer)
+        !Array.isArray(to.query.referrer)
       ) {
-        return navigateTo(route.query.referrer || localePath('/dashboard/'))
+        return navigateTo(to.query.referrer || localePath('/dashboard/'))
       }
     }),
   ],


### PR DESCRIPTION
A page middleware should always use the `to` parameter to access the route.