### PR TITLE
fix(upload): allow removal on invalid storage key

### DIFF
--- a/nuxt/server/api/tusd.ts
+++ b/nuxt/server/api/tusd.ts
@@ -165,29 +165,18 @@ const tusdDelete = async (event: H3Event) => {
       method: 'DELETE',
     })
 
-    if (httpResp.ok) {
-      if (httpResp.status === 204) {
-        await deleteUpload(event, uploadId, storageKey)
-        event.node.res.statusCode = 204
-        await send(event)
-      } else if (httpResp.status === 404) {
-        await deleteUpload(event, uploadId, storageKey)
-      } else {
-        return sendError(
-          event,
-          createError({
-            statusCode: 500,
-            statusMessage: 'Tusd status was "' + httpResp.status + '".',
-          })
-        )
-      }
+    if (httpResp.status === 204) {
+      await deleteUpload(event, uploadId, storageKey)
+      event.node.res.statusCode = 204
+      await send(event)
+    } else if (httpResp.status === 404) {
+      await deleteUpload(event, uploadId, storageKey)
     } else {
-      sendError(
+      return sendError(
         event,
         createError({
           statusCode: 500,
-          statusMessage:
-            'Internal delete failed: "' + httpResp.statusText + '"!',
+          statusMessage: 'Tusd status was "' + httpResp.status + '".',
         })
       )
     }


### PR DESCRIPTION
When an upload's binary data is removed, the storage key saved to maevsi's db does not resolve and leads to a 404. You can try that by creating an upload, then removing it in minio only. Obviously a 404 is not `ok`, so that `if` needs to be removed.