### PR TITLE
refactor(ical): check api method via file name

### DIFF
--- a/src/server/api/ical.post.ts
+++ b/src/server/api/ical.post.ts
@@ -12,14 +12,7 @@ import {
 } from '~/gql/generated/graphql'
 
 export default defineEventHandler(async (h3Event: H3Event) => {
-  const { req, res } = h3Event.node
-
-  if (req.method !== 'POST')
-    throw createError({
-      statusCode: 405,
-      statusMessage: 'Only POST requests are allowed!',
-    })
-
+  const { res } = h3Event.node
   const body = await readBody(h3Event)
   const host = getHost(h3Event)
 

--- a/src/tests/unit/ical.test.ts
+++ b/src/tests/unit/ical.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
-import { getIcalString } from '~/server/api/ical'
+import { getIcalString } from '~/server/api/ical.post'
 
 beforeEach(() => {
   vi.useFakeTimers()


### PR DESCRIPTION
I renamed the api file so that it's not necessary to check the method being used internally.