### PR TITLE
chore(server): customize types

### DIFF
--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -1,3 +1,16 @@
 {
-  "extends": "../.nuxt/tsconfig.server.json"
+  "extends": "../.nuxt/tsconfig.server.json",
+  // TODO: remove customizations below once there is better support for server types in Nuxt (https://github.com/nuxt/nuxt/issues/21484)
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "..",
+    "paths": {
+      "~": [
+        "."
+      ],
+      "~/*": [
+        "./*"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
After adding [server types](https://nuxt.com/docs/guide/directory-structure/server#server-types) some imports do not show correctly. This PR adds a workaround until better Nuxt generated types are available.