### PR TITLE
fix(card): allow vertical overflow

### DIFF
--- a/src/components/card/Card.vue
+++ b/src/components/card/Card.vue
@@ -1,6 +1,7 @@
 <template>
+  <!-- TODO: hide or show overflow completely -->
   <div
-    class="overflow-hidden rounded-lg"
+    class="overflow-x-hidden rounded-lg"
     :class="[backgroundColor, ...(isHigh ? ['px-4 py-6'] : ['p-4'])]"
   >
     <slot />


### PR DESCRIPTION
When hiding all `Card` overflows, as currently done on `beta`, modals do not allow to scroll content. This PR allows scrolling in modals again.