### PR TITLE
feat(security): add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# maevsi Disclosure Policy
+
+## 1 Introduction
+
+The security of maevsi is a top priority for our team. We believe in transparency and collaboration with the community to identify and address potential security vulnerabilities. This disclosure policy outlines the procedures for reporting security issues in maevsi and how we handle such reports.
+
+## 2 Reporting a Security Issue
+
+If you discover a security vulnerability in maevsi, we encourage you to report it to us promptly. To report a security issue, please follow these steps:
+
+
+Send an email to contact+security@maev.si with the subject line "Security Issue: [Brief Description]." Please provide a detailed description of the vulnerability, including the following:
+
+A concise summary of the issue.
+A detailed explanation of the vulnerability and its potential impact.
+Steps to reproduce the vulnerability (if applicable).
+Any additional information that can help us understand and address the issue.
+
+## 3. Handling of Reports
+
+Upon receiving a security report, the maevsi team will follow these steps:
+
+### 3.1 Acknowledgment
+
+We will acknowledge your report as soon as possible and provide an estimated timeline for the review and resolution process.
+
+### 3.2 Evaluation
+
+Our team will review the reported issue to assess its validity and severity. We may request additional information from you if necessary.
+
+### 3.3 Resolution
+
+Once we have confirmed and understood the vulnerability, we will develop and test a fix. We will try to resolve the issue as quickly as possible.
+
+### 3.4 Communication
+
+We will keep you informed of our progress throughout the process and notify you when a fix is available. If the issue affects multiple projects, we may coordinate with other project maintainers and vendors.
+
+## 4 Disclosure
+
+We believe in responsible disclosure to protect our users. 
+
+If the issue is resolved, we will coordinate with you to establish a mutually agreed-upon release date for the fix.
+We will issue a security advisory and update the project's documentation once the fix is publicly available.
+
+## 5 Credit and Recognition
+
+We highly value the contributions of the security community and will provide credit to individuals or organizations who responsibly report security vulnerabilities. However, if you prefer to remain anonymous, we will respect your wishes.
+
+## 6 Legal Protection
+
+maevsi will not pursue legal action against security researchers who follow this disclosure policy and act in good faith. We appreciate your efforts to help us maintain the security of our project.
+
+
+## 7 Changes to this Policy
+
+This security disclosure policy may be updated or revised from time to time.
+
+Last Updated: 2024-09-12

--- a/SECURITY_CONTRIBUTION.md
+++ b/SECURITY_CONTRIBUTION.md
@@ -1,0 +1,3 @@
+# Security Contributions
+The following security researchers followed our offical disclosure policy and helped us secure maevsi:
+- None yet, be the first!

--- a/src/public/.well-known/security.txt
+++ b/src/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:contact+security@maev.si
+Expires: 2024-09-12T11:00:00.000Z
+Acknowledgments: https://github.com/maevsi/maevsi/SECURITY_CONTRIBUTION.md
+Preferred-Languages: en, de
+Policy: https://github.com/maevsi/maevsi/SECURITY.md


### PR DESCRIPTION
I added a security.txt file which also references the security markdown file. Besides that I added a security contribution file where we can list security researchers.

Closes #1045 