### PR TITLE
feat(sentry): expose sample rates to runtime configuration

### DIFF
--- a/src/composables/sentry.ts
+++ b/src/composables/sentry.ts
@@ -1,8 +1,8 @@
-export const useSentryConfig = () => {
+export const useSharedSentryConfig = () => {
   const isTesting = useIsTesting()
   const runtimeConfig = useRuntimeConfig()
 
-  return getSentryConfig({
+  return getSharedSentryConfig({
     environment: runtimeConfig.public.vio.environment,
     host: runtimeConfig.public.sentry.host,
     isInProduction: runtimeConfig.public.vio.isInProduction,
@@ -13,7 +13,7 @@ export const useSentryConfig = () => {
   })
 }
 
-export const getSentryConfig = ({
+export const getSharedSentryConfig = ({
   environment,
   host,
   isInProduction,

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -127,6 +127,9 @@ export default defineNuxtConfig({
       },
       sentry: {
         host: 'o4506083883352064.ingest.sentry.io',
+        profiles: {
+          sampleRate: 1.0,
+        },
         project: {
           client: {
             id: '4506114193817600',
@@ -135,6 +138,14 @@ export default defineNuxtConfig({
           server: {
             id: '4506114183528448',
             publicKey: 'be543bc70951bae8ed5bc5874b99b112',
+          },
+        },
+        replays: {
+          onError: {
+            sampleRate: 1.0,
+          },
+          session: {
+            sampleRate: 0.0,
           },
         },
       },

--- a/src/plugins/sentry.client.ts
+++ b/src/plugins/sentry.client.ts
@@ -2,10 +2,11 @@ import * as Sentry from '@sentry/vue'
 import { consola } from 'consola'
 
 export default defineNuxtPlugin((nuxtApp) => {
+  const runtimeConfig = useRuntimeConfig()
   const router = useRouter()
-  const sentryConfig = useSentryConfig()
+  const sharedSentryConfig = useSharedSentryConfig()
 
-  if (!sentryConfig.dsn) {
+  if (!sharedSentryConfig.dsn) {
     consola.warn(
       'Sentry configuration is incomplete, skipping Sentry initialization.',
     )
@@ -13,7 +14,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   Sentry.init({
-    ...sentryConfig,
+    ...sharedSentryConfig,
     app: nuxtApp.vueApp,
     integrations: [
       new Sentry.BrowserTracing({
@@ -21,12 +22,14 @@ export default defineNuxtPlugin((nuxtApp) => {
       }),
       new Sentry.Replay(),
     ],
-    replaysOnErrorSampleRate: 1.0, // lower as soon as there are too many events
-    replaysSessionSampleRate: 0.0, // lower as soon as there are too many events
+    replaysOnErrorSampleRate:
+      runtimeConfig.public.sentry.replays.onError.sampleRate,
+    replaysSessionSampleRate:
+      runtimeConfig.public.sentry.replays.session.sampleRate,
     tracePropagationTargets: [
       'localhost',
       'https://maev.si',
       'https://maevsi.com',
-    ], // control for which URLs distributed tracing should be enabled
+    ],
   })
 })

--- a/src/server/plugins/sentry.ts
+++ b/src/server/plugins/sentry.ts
@@ -4,7 +4,7 @@ import { consola } from 'consola'
 
 export default defineNitroPlugin((nitroApp) => {
   const runtimeConfig = useRuntimeConfig()
-  const sentryConfig = getSentryConfig({
+  const sentryConfig = getSharedSentryConfig({
     environment: runtimeConfig.public.vio.environment,
     host: runtimeConfig.public.sentry.host,
     isInProduction: runtimeConfig.public.vio.isInProduction,
@@ -25,7 +25,7 @@ export default defineNitroPlugin((nitroApp) => {
     ...sentryConfig,
     // TODO: enable profiling (https://github.com/getsentry/profiling-node/issues/195)
     // integrations: [new ProfilingIntegration()],
-    // profilesSampleRate: 1.0, // profiling sample rate is relative to traces sample rate
+    // profilesSampleRate: runtimeConfig.public.sentry.profiles.sampleRate, // profiling sample rate is relative to traces sample rate
   })
 
   nitroApp.hooks.hook('error', (error) => {

--- a/src/server/utils/util.ts
+++ b/src/server/utils/util.ts
@@ -1,1 +1,1 @@
-export { getSentryConfig } from '~/composables/sentry'
+export { getSharedSentryConfig } from '~/composables/sentry'


### PR DESCRIPTION
### 📚 Description

Expose Sentry's sample rates to runtime configuration.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
