### PR TITLE
fix(nuxt): read release name from environment variable

### DIFF
--- a/.github/workflows/browserslist-regex.yml
+++ b/.github/workflows/browserslist-regex.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   browserslist-regex:
-    uses: dargmuesli/github-actions/.github/workflows/browserslist-regex.yml@1.5.0
+    uses: dargmuesli/github-actions/.github/workflows/browserslist-regex.yml@2.0.0-beta.1
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   release_semantic_dry:
     needs: prepare_jobs
     name: Release (semantic, dry)
-    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@1.5.0
+    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@2.0.0-beta.1
     if: needs.prepare_jobs.outputs.pr_found == 'false' || github.event_name == 'pull_request'
     permissions:
       contents: write
@@ -35,18 +35,19 @@ jobs:
       DRY_RUN: true
   build:
     name: Build
-    uses: dargmuesli/github-actions/.github/workflows/docker.yml@1.5.0
+    uses: dargmuesli/github-actions/.github/workflows/docker.yml@2.0.0-beta.1
     needs: release_semantic_dry
     permissions:
       packages: write
     with:
+      BUILD_ARGUMENTS_RELEASE: RELEASE_NAME=${{ needs.release_semantic_dry.outputs.new_release_version }}
       TAG: ${{ needs.release_semantic_dry.outputs.new_release_version }}
     secrets:
-      BUILD_ARGUMENTS_CI: SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+      BUILD_ARGUMENTS_RELEASE: SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
   release_semantic:
     needs: build
     name: Release (semantic)
-    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@1.5.0
+    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@2.0.0-beta.1
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-schedule:
     name: "Release: Scheduled"
-    uses: dargmuesli/github-actions/.github/workflows/release-schedule.yml@1.5.0
+    uses: dargmuesli/github-actions/.github/workflows/release-schedule.yml@2.0.0-beta.1
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     with:

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -12,6 +12,7 @@ import { SITE_NAME, SITE_URL } from './utils/constants'
 
 const execPromise = promisify(exec)
 const RELEASE_NAME = async () =>
+  process.env.RELEASE_NAME ||
   (await execPromise('git describe --tags')).stdout.trim()
 
 // TODO: let this error in "eslint (compat/compat)"" (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/55519)


### PR DESCRIPTION
### 📚 Description

Read release name from environment variable so that the upcoming release is preferred in contrast to the still current commit.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
