### PR TITLE
fix(breadcrumbs): correct separator icon

### DIFF
--- a/src/components/layout/LayoutBreadcrumbs.vue
+++ b/src/components/layout/LayoutBreadcrumbs.vue
@@ -9,12 +9,18 @@
         iconWithLabel: 'mr-1',
         default: ITEM_UI,
         current: ITEM_UI,
-        separator: 'ml-2 text-gray-400 dark:text-gray-600',
       },
     }"
   >
     <template #icon>
       <IHeroiconsHome />
+    </template>
+    <template #separator>
+      <IHeroiconsChevronRight
+        class="ml-2 text-gray-600 dark:text-gray-400"
+        height="1em"
+        width="1em"
+      />
     </template>
   </SBreadcrumb>
 </template>


### PR DESCRIPTION
### 📚 Description

Fix missing icon for separators in breadcrumbs.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
