### PR TITLE
chore(tailwind): remove postcss configuration

### DIFF
--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -109,9 +109,6 @@ export default defineNuxtConfig({
   nitro: {
     compressPublicAssets: true,
   },
-  postcss: {
-    plugins: { tailwindcss: {}, autoprefixer: {} },
-  },
   runtimeConfig: {
     public: {
       i18n: {


### PR DESCRIPTION
### 📚 Description

The postcss configuration should not be needed anymore now that `@nuxtjs/tailwindcss` is in use.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
