### PR TITLE
feat(session): allow to create when already signed in

### DIFF
--- a/src/pages/session/create.vue
+++ b/src/pages/session/create.vue
@@ -4,22 +4,15 @@
       {{ t('accountRequired') }}
     </CardStateInfo>
     <LayoutPageTitle :title="title" />
-    <div
-      v-if="
-        !store.jwtDecoded?.role || store.jwtDecoded.role === 'maevsi_anonymous'
-      "
-      class="flex justify-center"
-    >
+    <div class="flex justify-center">
       <FormAccountSignIn class="max-w-lg grow" @signed-in="onSignIn" />
     </div>
-    <Error v-else :status-code="422" />
   </div>
 </template>
 
 <script setup lang="ts">
 const { t } = useI18n()
 const localePath = useLocalePath()
-const store = useMaevsiStore()
 const route = useRoute()
 
 // data


### PR DESCRIPTION
See https://github.com/maevsi/maevsi/issues/1510

### 📚 Description

Removes the error on the sign in page when already signed in.

### 📝 Checklist

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
