### PR TITLE
feat: populate env vars from secret files in docker entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,31 @@
 #!/bin/sh
 set -e
 
+# extract all secrets referenced as env vars MY_VAR_SECRETSFILE to MY_VAR
+for var in $(env | cut -d'=' -f1); do
+  # Check if the variable name ends with _SECRETSFILE
+  if [ "$(echo "$var" | grep "_SECRETSFILE$")" ]; then
+    # Extract the base variable name (without _SECRETSFILE suffix)
+    base_var="$(echo "$var" | sed 's/_SECRETSFILE$//')"
+
+    # Check if the base variable is not already set
+    if [ -z "$(eval echo \"\$$base_var\")" ]; then
+      # Get the file path from the variable
+      file_path="$(eval echo \"\$$var\")"
+
+      echo "Populate secret: '$base_var' from '$file_path'."
+
+      # Check if the file exists
+      if [ -f "$file_path" ]; then
+        # Read the content of the file and set it to the base variable
+        export "$base_var"="$(cat "$file_path")"
+      else
+        echo "Warning: File '$file_path' specified by '$var' does not exist."
+      fi
+    fi
+  fi
+done
+
 pnpm config set store-dir "/srv/.pnpm-store"
 pnpm install
 pnpm rebuild -r


### PR DESCRIPTION
### 📚 Description

Docker swarm does only support secrets as files. Nuxt reads env vars automatically and populates the typed runtimeConfig with it. At the moment this is handled in application code, which is repetitive and not deployment agnostic. It also causes issue in frontend only mode, where developers need to setup files.
See an example of current handling [in tusd utils](https://github.com/maevsi/maevsi/blob/master/src/server/utils/tusd.ts)

This PR moves this handling out of application code to the docker entrypoint.

All env vars with suffix _SECRETSFILE populate there suffix-less version now with the secret inside the file.
This means, we can configure a docker secret /run/secret/my_secret=super-secret, configure environment variable NUXT_MY_SECRET_SECRETSFILE=/run/secret/my_secret and access runtimeConfig.mySecret=super-secret in application code.

I've not cleaned up the the existing code yet, but I run across this in context of oauth2 config

### 📝 Checklist

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
