### PR TITLE
fix(gtag): update consent on initial page load

### DIFF
--- a/src/composables/gtag.ts
+++ b/src/composables/gtag.ts
@@ -6,9 +6,27 @@ export const useMaevsiGtag = () => {
     enableAnalytics,
   } = useGtag()
   const cookieControl = useCookieControl()
+  const updateConsent = ({ isGranted }: { isGranted: boolean }) => {
+    gtag('consent', 'update', {
+      // // the following are denied per default in the gtag module configuration
+      // ad_user_data: 'denied',
+      // ad_personalization: 'denied',
+      // ad_storage: 'denied',
+      analytics_storage: isGranted ? 'granted' : 'denied',
+    })
+  }
+  const enableGtag = () => {
+    updateConsent({ isGranted: true })
+    initializeGtag()
+    enableAnalytics()
+  }
+  const disableGtag = () => {
+    updateConsent({ isGranted: false })
+    disableAnalytics()
+  }
 
   if (cookieControl.cookiesEnabledIds.value?.includes(GTAG_COOKIE_ID)) {
-    initializeGtag()
+    enableGtag()
   }
 
   watch(cookieControl.cookiesEnabledIds, (current, previous) => {
@@ -16,21 +34,14 @@ export const useMaevsiGtag = () => {
       !previous?.includes(GTAG_COOKIE_ID) &&
       current?.includes(GTAG_COOKIE_ID)
     ) {
-      gtag('consent', 'update', {
-        ad_user_data: 'denied',
-        ad_personalization: 'denied',
-        ad_storage: 'denied',
-        analytics_storage: 'granted',
-      })
-      initializeGtag()
-      enableAnalytics()
+      enableGtag()
     }
 
     if (
       previous?.includes(GTAG_COOKIE_ID) &&
       !current?.includes(GTAG_COOKIE_ID)
     ) {
-      disableAnalytics()
+      disableGtag()
     }
   })
 }

--- a/src/config/environments/development.ts
+++ b/src/config/environments/development.ts
@@ -14,6 +14,9 @@ export const developmentConfig: ReturnType<DefineNuxtConfig> = {
     },
 
     // modules
+    gtag: {
+      enabled: false,
+    },
     security: {
       headers: {
         strictTransportSecurity: false,


### PR DESCRIPTION
### 📚 Description

Currently, the consent does not seem to update on initial page load, which it should. Therefore all consent is denied in future page visits after giving consent. This PR changes the behavior of consent updates.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
