### PR TITLE
fix(security): disable xss validator on internal authentication proxy

### DIFF
--- a/src/.config/nuxt.ts
+++ b/src/.config/nuxt.ts
@@ -115,6 +115,13 @@ export default defineNuxtConfig({
       openAPI: IS_NITRO_OPENAPI_ENABLED,
     },
   },
+  routeRules: {
+    '/api/auth-proxy': {
+      security: {
+        xssValidator: false, // TipTap's HTML is stored unescaped (is escaped when displayed) so api requests would trigger the xss protection on forward authentication (https://github.com/maevsi/maevsi/issues/1603)
+      },
+    },
+  },
   runtimeConfig: {
     public: {
       i18n: {


### PR DESCRIPTION
### 📚 Description

TipTap's HTML is stored unescaped (is escaped when displayed) so api requests would trigger the xss protection on forward authentication.

Resolves https://github.com/maevsi/maevsi/issues/1603

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
