### PR TITLE
fix(form): set captcha token on submit instead of on fetch

### DIFF
--- a/src/components/form/account/FormAccountRegistration.vue
+++ b/src/components/form/account/FormAccountRegistration.vue
@@ -57,6 +57,7 @@ import { useAccountRegistrationMutation } from '~/gql/documents/mutations/accoun
 const { locale, t } = useI18n()
 const localePath = useLocalePath()
 const fireAlert = useFireAlert()
+const store = useMaevsiStore()
 
 // api data
 const accountRegistrationMutation = useAccountRegistrationMutation()
@@ -74,6 +75,8 @@ const isFormSent = ref(false)
 // methods
 const submit = async () => {
   if (!(await isFormValid({ v$, isFormSent }))) return
+
+  store.turnstileToken = form.captcha
 
   const result = await accountRegistrationMutation.executeMutation({
     emailAddress: form.emailAddress || '',

--- a/src/components/form/account/FormAccountSignIn.vue
+++ b/src/components/form/account/FormAccountSignIn.vue
@@ -75,6 +75,7 @@ const fireAlert = useFireAlert()
 const { t } = useI18n()
 const { jwtStore } = useJwtStore()
 const localePath = useLocalePath()
+const store = useMaevsiStore()
 
 // api data
 const accountRegistrationRefreshMutation =
@@ -96,6 +97,8 @@ const isFormSent = ref(false)
 // methods
 const submit = async () => {
   if (!(await isFormValid({ v$, isFormSent }))) return
+
+  store.turnstileToken = form.captcha
 
   const result = await authenticateMutation.executeMutation({
     username: form.username || '',

--- a/src/components/form/input/FormInputCaptcha.vue
+++ b/src/components/form/input/FormInputCaptcha.vue
@@ -64,7 +64,6 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const store = useMaevsiStore()
 const colorMode = useColorMode()
 const runtimeConfig = useRuntimeConfig()
 
@@ -108,7 +107,6 @@ const reset = () => {
 }
 const update = (e: string) => {
   isLoading.value = false
-  store.turnstileToken = e
   emit('input', e)
 }
 


### PR DESCRIPTION


### 📚 Description

The token is only valid once. If it is set directly after retrieving it, it'll be used for the first request following and unset directly afterwards. In case of the registration form that would be likely the username existence check and the token would not be valid for the form submission later on.
Now we set the token on form submission only.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
