### PR TITLE
feat(email): allow change to 24h limit through environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:static": "nuxt --dir src run generate",
     "dev": "pnpm --dir src run start:dev",
     "generate": "pnpm --dir src run build:static",
+    "lint": "pnpm -r lint",
     "prepare": "husky",
     "start:dev": "pnpm --dir src exec nuxt dev",
     "start:node": "node src/.output/server/index.mjs",

--- a/src/.config/nuxt.ts
+++ b/src/.config/nuxt.ts
@@ -141,6 +141,11 @@ export default defineNuxtConfig({
       i18n: {
         baseUrl: SITE_URL,
       },
+      maevsi: {
+        email: {
+          limit24h: '150',
+        },
+      },
       sentry: {
         host: 'o4507213726154752.ingest.de.sentry.io',
         profiles: {

--- a/src/server/plugins/event-stream.ts
+++ b/src/server/plugins/event-stream.ts
@@ -43,7 +43,7 @@ export default defineNitroPlugin(async (nitroApp) => {
                 payload: JSON.parse(value.payload.after.payload),
               },
               id: key.payload.id,
-              is_acknowledged: value.payload.after.is_acknowledged,
+              isAcknowledged: value.payload.after.is_acknowledged,
               runtimeConfig,
             })
           } catch (error) {

--- a/src/server/plugins/event-stream.ts
+++ b/src/server/plugins/event-stream.ts
@@ -3,6 +3,8 @@ const TOPIC_NOTIFICATION = 'maevsi.maevsi_private.notification'
 export default defineNitroPlugin(async (nitroApp) => {
   if (!IS_IN_STACK) return
 
+  const runtimeConfig = useRuntimeConfig()
+
   const { Kafka } = await import('kafkajs')
   const kafka = new Kafka({
     clientId: 'maevsi',
@@ -42,6 +44,7 @@ export default defineNitroPlugin(async (nitroApp) => {
               },
               id: key.payload.id,
               is_acknowledged: value.payload.after.is_acknowledged,
+              runtimeConfig,
             })
           } catch (error) {
             console.error(`Failed to process notification: ${error}`)

--- a/src/server/utils/constants.ts
+++ b/src/server/utils/constants.ts
@@ -7,6 +7,7 @@ import {
 } from '../../shared/utils/constants'
 import { getDomainTldPort as getSiteAndPort } from '../../shared/utils/networking'
 
+export const MAEVSI_EMAIL_LIMIT_24H = 150
 export const IS_IN_PRODUCTION = process.env.NODE_ENV === 'production'
 export const IS_IN_STACK = !!process.env.NUXT_PUBLIC_SITE_URL
 export const IS_IN_FRONTEND_DEVELOPMENT = !IS_IN_PRODUCTION && !IS_IN_STACK

--- a/src/server/utils/email.ts
+++ b/src/server/utils/email.ts
@@ -99,7 +99,7 @@ export const sendEmail = async <T extends EmailName>({
         value: `mailto:contact+unsubscribe@maev.si?subject=Unsubscribe%20${mailOptions.to}`,
       },
     },
-    // // TODO: wait for long line fix (https://github.com/nodemailer/nodemailer/issues/1654)
+    // // TODO: wait for long line fix (https://github.com/nodemailer/nodemailer/issues/1694)
     // list: {
     //   // TODO: add https link (https://github.com/maevsi/maevsi/issues/326)
     //   unsubscribe: `mailto:contact+unsubscribe@maev.si?subject=Unsubscribe%20${mailOptions.to}`,

--- a/src/server/utils/email.ts
+++ b/src/server/utils/email.ts
@@ -57,10 +57,12 @@ export const getEmail = async <T extends EmailName>({
   })
 
 export const sendEmail = async <T extends EmailName>({
+  limit24h,
   mailOptions,
   name,
   props,
 }: {
+  limit24h: number
   mailOptions: {
     fromName?: string
     icalEvent?: Record<string, unknown> // https://nodemailer.com/message/calendar-events/
@@ -135,11 +137,10 @@ export const sendEmail = async <T extends EmailName>({
 
   // TODO: implement proper rate limiting
   const sentLast24Hours = await getMailsSentLast24Hours()
-  const LIMIT = 150
-  if (sentLast24Hours && sentLast24Hours > LIMIT) {
+  if (sentLast24Hours && sentLast24Hours > limit24h) {
     // TODO: notify admin
     throw new Error(
-      `More than ${LIMIT} mails sent in the last 24 hours, not sending any more for now to prevent spamming.`,
+      `More than ${limit24h} mails sent in the last 24 hours, not sending any more for now to prevent spamming.`,
     )
   }
 

--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -124,15 +124,15 @@ const locales = {
 export const processNotification = async ({
   channelEvent,
   id,
-  is_acknowledged,
+  isAcknowledged,
   runtimeConfig,
 }: {
   channelEvent: ChannelEvent
   id: string
-  is_acknowledged?: boolean
+  isAcknowledged?: boolean
   runtimeConfig: ReturnType<typeof useRuntimeConfig>
 }) => {
-  if (is_acknowledged) return
+  if (isAcknowledged) return
 
   const limit24h = isNaN(+runtimeConfig.public.maevsi.email.limit24h)
     ? undefined

--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -125,20 +125,32 @@ export const processNotification = async ({
   channelEvent,
   id,
   is_acknowledged,
+  runtimeConfig,
 }: {
   channelEvent: ChannelEvent
   id: string
   is_acknowledged?: boolean
+  runtimeConfig: ReturnType<typeof useRuntimeConfig>
 }) => {
   if (is_acknowledged) return
 
-  const { channel, payload } = channelEvent
+  const limit24h = isNaN(+runtimeConfig.public.maevsi.email.limit24h)
+    ? undefined
+    : +runtimeConfig.public.maevsi.email.limit24h
 
+  if (!limit24h) {
+    console.warn(
+      `24h email limit is not a number, using default: ${MAEVSI_EMAIL_LIMIT_24H}`,
+    )
+  }
+
+  const { channel, payload } = channelEvent
   const locale = payload.template.language as unknown as Locale
 
   switch (channel) {
     case CHANNEL_NAME_ACCOUNT_PASSWORD_RESET:
       await sendEmail({
+        limit24h: limit24h || MAEVSI_EMAIL_LIMIT_24H,
         mailOptions: {
           subject: locales[channel][locale].subject,
           to: payload.account.email_address,
@@ -167,6 +179,7 @@ export const processNotification = async ({
       break
     case CHANNEL_NAME_ACCOUNT_REGISTRATION:
       await sendEmail({
+        limit24h: limit24h || MAEVSI_EMAIL_LIMIT_24H,
         mailOptions: {
           subject: locales[channel][locale].subject,
           to: payload.account.email_address,
@@ -192,7 +205,10 @@ export const processNotification = async ({
       })
       break
     case CHANNEL_NAME_EVENT_INVITATION:
-      sendEventInvitationMail(channelEvent)
+      sendEventInvitationMail({
+        limit24h: limit24h || MAEVSI_EMAIL_LIMIT_24H,
+        channelEvent,
+      })
       break
     default:
       throw new Error(`Unexpected channel: ${channel}`)
@@ -218,9 +234,13 @@ const ack = async ({ id }: { id: string }) => {
     console.error(`Could not ack due to error: "${response.statusText}"`)
 }
 
-export const sendEventInvitationMail = async (
-  channelEvent: EventInvitationEvent,
-) => {
+export const sendEventInvitationMail = async ({
+  channelEvent,
+  limit24h,
+}: {
+  channelEvent: EventInvitationEvent
+  limit24h: number
+}) => {
   const { channel, payload } = channelEvent
   const payloadCamelCased = camelcaseKeys(payload, { deep: true })
 
@@ -311,6 +331,7 @@ export const sendEventInvitationMail = async (
   }
 
   await sendEmail({
+    limit24h,
     mailOptions: {
       fromName: eventAuthorUsername,
       icalEvent: {


### PR DESCRIPTION
### 📚 Description

Instead of hardcoding a magic number only, let the email's 24h sending limit be configurable through environment variables too. The magic number stays as a fallback.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commmits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format
- [x] The PR's title follows the Conventional Commit format
