### PR TITLE
chore(semantic): revert to default

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,5 +1,0 @@
-# Always validate the PR title AND all the commits
-titleAndCommits: true
-# Allows use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
-# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
-allowMergeCommits: true


### PR DESCRIPTION
### 📚 Description

As we're using squash merges now and only the PR title lands on the default branch as commit title, we can use the default semantic configuration again.

@huzaifaedhi22 if you merge master into your branches that are currently failing because of commit title formatting after this PR is merged (feel free to merge), they shouldn't be failing anymore.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
