### PR TITLE
fix(vite): allow host `maevsi`

### DIFF
--- a/src/config/environments/development.ts
+++ b/src/config/environments/development.ts
@@ -12,6 +12,11 @@ export const developmentConfig: ReturnType<DefineNuxtConfig> = {
         },
       },
     },
+    vite: {
+      server: {
+        allowedHosts: ['maevsi'],
+      },
+    },
 
     // modules
     gtag: {

--- a/src/config/environments/development.ts
+++ b/src/config/environments/development.ts
@@ -16,6 +16,15 @@ export const developmentConfig: ReturnType<DefineNuxtConfig> = {
       server: {
         allowedHosts: ['maevsi'],
       },
+      ssr: {
+        noExternal: [
+          // TODO: remove (https://github.com/nuxt/nuxt/issues/30749)
+          'detect-libc',
+          'node-abi',
+          '@sentry/profiling-node',
+          'tailwindcss',
+        ],
+      },
     },
 
     // modules


### PR DESCRIPTION

### 📚 Description

Following a security fix in vite (https://github.com/advisories/GHSA-vg6x-rcgg-rjx6) we must now specify that `maevsi` is a valid host which comes into play in our stack deployment.

We also currently need to mark a few dependencies as not to be externalized by vite due to a regression in Nuxt (https://github.com/nuxt/nuxt/issues/30749).
### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
