### PR TITLE
fix(sentry): disable server wrapper

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -161,7 +161,8 @@
     "prepare": "nuxt prepare",
     "start": "pnpm run start:node",
     "start:dev": "nuxt dev",
-    "start:node": "node --import ./.output/server/sentry.server.config.mjs .output/server/index.mjs",
+    "start:node": "node .output/server/index.mjs",
+    "start:node:sentry": "node --import .output/server/sentry.server.config.mjs .output/server/index.mjs",
     "start:static": "serve .output/public",
     "supportedBrowsers": "echo \"export default $(browserslist-useragent-regexp --allowHigherVersions);\" > supportedBrowsers.js"
   },


### PR DESCRIPTION
### 📚 Description

The Nuxt server does not start with the current Sentry wrapper in production. There is no log indicating why. This disables the Sentry wrapper per default and keeps it as an alias for future debugging.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
