### PR TITLE
refactor(server): extract "composables"

### DIFF
--- a/src/server/api/upload.delete.ts
+++ b/src/server/api/upload.delete.ts
@@ -5,7 +5,9 @@ const uploadDeleteQuerySchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
-  await verifyAuth(event)
+  const verifyAuth = await useVerifyAuth()
+
+  await verifyAuth()
 
   const query = await getQuerySafe({ event, schema: uploadDeleteQuerySchema })
   const uploadId = query.uploadId

--- a/src/server/middleware/timezone.ts
+++ b/src/server/middleware/timezone.ts
@@ -1,3 +1,5 @@
 export default defineEventHandler(async (event) => {
-  event.context.$timezone = await getTimezoneServer(event)
+  const timezone = await useTimezone()
+
+  event.context.$timezone = timezone
 })

--- a/src/server/utils/testing.ts
+++ b/src/server/utils/testing.ts
@@ -1,7 +1,20 @@
 import type { H3Event } from 'h3'
 
-export const isTestingServer = (event?: H3Event) => {
-  const isTestingByRuntimeConfig = useRuntimeConfig().public.vio.isTesting
+export const useIsTesting = () => {
+  const event = useEvent()
+  const runtimeConfig = useRuntimeConfig()
+
+  return getIsTesting({ event, runtimeConfig })
+}
+
+export const getIsTesting = ({
+  event,
+  runtimeConfig,
+}: {
+  event?: H3Event
+  runtimeConfig: ReturnType<typeof useRuntimeConfig>
+}) => {
+  const isTestingByRuntimeConfig = runtimeConfig.public.vio.isTesting
 
   if (isTestingByRuntimeConfig) return true
 


### PR DESCRIPTION
### 📚 Description

Convert come server utilities to the logic known from composables in the frontend (they're just called `utils` in the backend, eventhough they start with `use` afaik). Makes use of Nitro's `asyncContext` feature to get `event` information.

Also makes use of the `getRequestHeader` function instead of reading form `node.req.headers`.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
