### PR TITLE
ci(docker): let pnpm fetch with correct version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ EXPOSE 3000
 
 FROM base-image AS prepare
 
-COPY ./pnpm-lock.yaml ./
+COPY ./pnpm-lock.yaml ./package.json ./
 
 RUN pnpm fetch
 


### PR DESCRIPTION
### 📚 Description

Should fix the `ERR_PNPM_NO_OFFLINE_TARBALL` pipeline issue.

The pnpm version that was used to run `pnpm fetch` was not the one specified in the `package.json` as that file was not yet available at runtime. The next pnpm command had the project's pnpm version available though which resulted in a mismatch.

I'd like to keep `package.json` not being copied and specify the package manager version to use in a separate config file, but I think this is currently the only place where one can configure the package manager.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
