### PR TITLE
fix(firebase): try initialization

### DIFF
--- a/src/server/api/notification.post.ts
+++ b/src/server/api/notification.post.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
   const runtimeConfig = useRuntimeConfig(event)
   const body = await getBodySafe({ event, schema: fcmMessageSchema })
 
-  if (!firebaseAdmin)
+  if (!firebaseAdminApp)
     return throwError({
       code: 500,
       message: 'Firebase uninitialized',
@@ -33,5 +33,5 @@ export default defineEventHandler(async (event) => {
       message: 'Invalid secret',
     })
 
-  return firebaseAdmin.messaging().send({ ...body.payload })
+  return firebaseAdminApp.messaging().send({ ...body.payload })
 })

--- a/src/server/utils/dependencies/firebase.ts
+++ b/src/server/utils/dependencies/firebase.ts
@@ -1,0 +1,17 @@
+import firebaseAdmin from 'firebase-admin'
+
+const getFirebaseAdminApp = () => {
+  if (!process.env.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS) return
+
+  try {
+    return firebaseAdmin.initializeApp({
+      credential: firebaseAdmin.credential.cert(
+        JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS),
+      ),
+    })
+  } catch (error) {
+    console.error('Failed to parse Firebase credentials:', error)
+  }
+}
+
+export const firebaseAdminApp = getFirebaseAdminApp()

--- a/src/server/utils/dependencies/index.ts
+++ b/src/server/utils/dependencies/index.ts
@@ -1,0 +1,1 @@
+export * from './firebase'

--- a/src/server/utils/firebase.ts
+++ b/src/server/utils/firebase.ts
@@ -1,9 +1,0 @@
-import admin from 'firebase-admin'
-
-export const firebaseAdmin = process.env.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS
-  ? admin.initializeApp({
-      credential: admin.credential.cert(
-        JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS),
-      ),
-    })
-  : undefined

--- a/src/server/utils/index.ts
+++ b/src/server/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './dependencies'


### PR DESCRIPTION
### 📚 Description

Wraps the firebase admin initialization in a try-catch-statement so that an error while parsing the credentials does not make the whole server fail to start.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
