### PR TITLE
fix(sentry): temporarily disable tracing

### DIFF
--- a/src/.config/nuxt.ts
+++ b/src/.config/nuxt.ts
@@ -57,7 +57,6 @@ export default defineNuxtConfig({
     '@nuxtjs/seo',
     '@nuxtjs/turnstile',
     '@pinia/nuxt',
-    '@sentry/nuxt/module',
     '@vite-pwa/nuxt',
     'nuxt-gtag',
     'shadcn-nuxt',

--- a/src/config/environments/production.ts
+++ b/src/config/environments/production.ts
@@ -2,6 +2,7 @@ import type { DefineNuxtConfig } from 'nuxt/config'
 
 export const productionConfig: ReturnType<DefineNuxtConfig> = {
   $production: {
+    modules: ['@sentry/nuxt/module'],
     runtimeConfig: {
       public: {
         vio: {

--- a/src/sentry.server.config.ts
+++ b/src/sentry.server.config.ts
@@ -33,7 +33,7 @@ Sentry.init({
     (process.env.NUXT_PUBLIC_VIO_IS_TESTING === 'true') === false,
   environment: process.env.NODE_ENV,
   // release: await RELEASE_NAME(), // TODO: enable once this file is moved to the `server` directory (https://github.com/getsentry/sentry-javascript/issues/14487),
-  tracesSampleRate: 1.0,
+  // tracesSampleRate: 1.0, // TODO: reenable when "require" bug is resolved in build
   integrations: [nodeProfilingIntegration()],
   profilesSampleRate: 1.0, // (isNaN(Number(process.env.NUXT_PUBLIC_SENTRY_PROFILES_SAMPLE_RATE)) ? undefined : Number(process.env.NUXT_PUBLIC_SENTRY_PROFILES_SAMPLE_RATE)) || NUXT_PUBLIC_SENTRY_PROFILES_SAMPLE_RATE, // profiling sample rate is relative to traces sample rate
 })


### PR DESCRIPTION
### 📚 Description

Sentry's tracing loads OpenTelemetry modules that internally use `require` which is not available in ESM.

This PR also disables Sentry in development.

cc @myyxl 

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
