### PR TITLE
fix(sw): use data field for notification

### DIFF
--- a/src/app/service-worker/sw.ts
+++ b/src/app/service-worker/sw.ts
@@ -6,6 +6,16 @@ import { initializeFirebaseClient } from '../utils/dependencies/firebase'
 
 declare let self: ServiceWorkerGlobalScope
 
+class CustomPushEvent extends Event {
+  custom: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(data: any) {
+    super('push')
+    Object.assign(this, data)
+    this.custom = true
+  }
+}
+
 cleanupOutdatedCaches()
 
 precacheAndRoute(self.__WB_MANIFEST)
@@ -14,11 +24,38 @@ self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting()
 })
 
+/*
+  Receive a push message with the notification field set
+  and move the notification data into the data field. 
+  This way firebase doesn't show the notification by
+  itself and we can implement the notification logic ourself.
+*/
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+self.addEventListener('push', (event: any) => {
+  if (event.custom) return
+
+  const customEvent = new CustomPushEvent({
+    // Push event data
+    data: {
+      // Actual data field
+      json() {
+        return { data: { ...event.data.json().notification } }
+      },
+    },
+    waitUntil: event.waitUntil.bind(event),
+  })
+  event.stopImmediatePropagation()
+
+  dispatchEvent(customEvent)
+})
+
 const firebaseApp = initializeFirebaseClient()
 onBackgroundMessage(getMessaging(firebaseApp), (payload) => {
-  if (!payload.notification?.title) return
+  if (!payload.data) return
 
-  const { title, body } = payload.notification
+  const { title, body } = payload.data
+
+  if (!title) return
 
   return self.registration.showNotification(title, { body })
 })


### PR DESCRIPTION
### 📚 Description

In the service worker the received notification message will be transformed into a data message, bypassing Firebase's own handler, so we can show the notification once.  

cc @dargmuesli

If you want to test it, remember to set the worker-src CSP.

I tested it on iOS bookmark and Chrome

@dargmuesli do you know how to handle the types here? Feel free to push, so we don't need to disable eslint.

### 📝 Checklist

- [x] The PR's title follows the Conventional Commit format
