### PR TITLE
ci(browserslist-regex): add dependency `mkcert`

### DIFF
--- a/.github/workflows/browserslist-regex.yml
+++ b/.github/workflows/browserslist-regex.yml
@@ -7,9 +7,11 @@ on:
 
 jobs:
   browserslist-regex:
-    uses: dargmuesli/github-actions/.github/workflows/browserslist-regex.yml@2.3.16
+    uses: dargmuesli/github-actions/.github/workflows/browserslist-regex.yml@2.5.0
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     with:
       DIRECTORY: src/
       NODE_VERSION: 22
+      UBUNTU_DEPENDENCIES: mkcert
+      UBUNTU_REPOSITORIES: universe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   release_semantic_dry:
     needs: prepare_jobs
     name: Release (semantic, dry)
-    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@2.3.16
+    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@2.5.0
     if: needs.prepare_jobs.outputs.pr_found == 'false' || github.event_name == 'pull_request'
     permissions:
       contents: write
@@ -36,7 +36,7 @@ jobs:
       DRY_RUN: true
   build:
     name: Build
-    uses: dargmuesli/github-actions/.github/workflows/docker.yml@2.3.16
+    uses: dargmuesli/github-actions/.github/workflows/docker.yml@2.5.0
     needs: release_semantic_dry
     permissions:
       packages: write
@@ -48,7 +48,7 @@ jobs:
   release_semantic:
     needs: build
     name: Release (semantic)
-    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@2.3.16
+    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@2.5.0
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-schedule:
     name: "Release: Scheduled"
-    uses: dargmuesli/github-actions/.github/workflows/release-schedule.yml@2.3.16
+    uses: dargmuesli/github-actions/.github/workflows/release-schedule.yml@2.5.0
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     with:


### PR DESCRIPTION
### 📚 Description

We now depend on `mkcert` but this wasn't added to all workflows yet.

cc @HMDank 

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] The PR's title follows the Conventional Commit format
