### PR TITLE
fix(app): stop nuxt's loading indicator from hiding errors

### DIFF
--- a/src/app/app.vue
+++ b/src/app/app.vue
@@ -5,7 +5,6 @@
     data-testid="is-loading"
     vaul-drawer-wrapper
   >
-    <NuxtLoadingIndicator />
     <LazyClientOnly>
       <CardStateInfo
         v-if="!isBrowserSupported && !runtimeConfig.public.vio.isTesting"
@@ -31,6 +30,7 @@
         </i18n-t>
       </CardStateInfo>
     </LazyClientOnly>
+    <NuxtLoadingIndicator />
     <NuxtLayout>
       <NuxtPage />
     </NuxtLayout>


### PR DESCRIPTION
### 📚 Description

Somehow the placement of the loading indicator can make error pages be swallowed, potentially only in development though.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
