### PR TITLE
fix(composables): rename shadowed variable

### DIFF
--- a/src/app/composables/auth.ts
+++ b/src/app/composables/auth.ts
@@ -1,11 +1,11 @@
 export const useAuth = async () => {
   const jwtFromCookie = useJwtFromCookie()
   const authenticateAnonymous = useAuthenticateAnonymous()
-  const jwtRefresh = useJwtRefresh()
+  const jwtRefreshComposable = useJwtRefresh() // TODO: rename to just `jwtRefreshComposable` when Rolldown supports variable shadowing
 
   if (import.meta.server) {
     if (jwtFromCookie?.jwtDecoded?.id) {
-      await jwtRefresh()
+      await jwtRefreshComposable()
     } else {
       await authenticateAnonymous()
     }


### PR DESCRIPTION
### 📚 Description

Rolldown gets confused by the shadowed variable. Can likely be renamed back in the future when Rolldown supports variable name shadowing.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
