### PR TITLE
chore(types): remove default export

### DIFF
--- a/src/shared/types/api.d.ts
+++ b/src/shared/types/api.d.ts
@@ -5,5 +5,3 @@ import type { GraphQLError } from 'graphql'
 export type BackendError = {
   graphQLErrors: (GraphQLError & { errcode?: string })[]
 } & CombinedError
-
-export default {} // workaround until fix in nitro is released (https://github.com/nitrojs/nitro/pull/3368)

--- a/src/shared/types/utility.d.ts
+++ b/src/shared/types/utility.d.ts
@@ -9,5 +9,3 @@ export type UnionToIntersection<T> = (
 ) extends (x: infer R) => unknown
   ? R
   : never
-
-export default {} // workaround until fix in nitro is released (https://github.com/nitrojs/nitro/pull/3368)


### PR DESCRIPTION
### 📚 Description

Upstream issue is resolved now so the workaround can be removed.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
