### PR TITLE
chore(modules): remove site url specification to read from i18n

### DIFF
--- a/src/.config/nuxt.ts
+++ b/src/.config/nuxt.ts
@@ -197,9 +197,6 @@ export default defineNuxtConfig({
       security: {
         isRateLimiterDisabled: true, // TODO: disable once api requests are optimized (https://github.com/maevsi/vibetype/issues/1654)
       },
-      site: {
-        url: SITE_URL,
-      },
       turnstile: {
         siteKey: '0x4AAAAAAABtEW1Hc8mcgWcZ',
       },

--- a/src/config/modules/index.ts
+++ b/src/config/modules/index.ts
@@ -1,6 +1,6 @@
 import type { DefineNuxtConfig } from 'nuxt/config'
 
-import { RELEASE_NAME, SITE_URL } from '../../node'
+import { RELEASE_NAME } from '../../node'
 import { cookieControlConfig } from './cookieControl'
 import { i18nConfig } from './i18n'
 import { pwaConfig } from './pwa'
@@ -67,9 +67,6 @@ export const modulesConfig: ReturnType<DefineNuxtConfig> = {
   shadcn: {
     prefix: '',
     componentDir: 'app/components/scn',
-  },
-  site: {
-    url: SITE_URL,
   },
   sitemap: {
     credits: false,

--- a/src/server/utils/jwt.ts
+++ b/src/server/utils/jwt.ts
@@ -50,7 +50,7 @@ export const setJwtCookie = ({
 }) => {
   const dateEpoch = new Date(0)
   const dateInAMonth = new Date(Date.now() + 86400 * 1000 * 31)
-  const siteUrl = new URL(runtimeConfig.public.site.url)
+  const siteUrl = new URL(runtimeConfig.public.i18n.baseUrl)
   const isHttps = siteUrl.protocol === 'https:'
   const jwtCookieName = JWT_NAME({ isHttps })
 

--- a/src/shared/utils/vio.ts
+++ b/src/shared/utils/vio.ts
@@ -1,6 +1,6 @@
 export const useSiteUrl = () => {
   const runtimeConfig = useRuntimeConfig()
-  const siteUrl = runtimeConfig.public.site?.url
+  const siteUrl = runtimeConfig.public.i18n.baseUrl
 
   return {
     siteUrl,


### PR DESCRIPTION
### 📚 Description

Let site configuration read the url from the i18n module's `baseUrl`.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
