### PR TITLE
perf(docker): add volume for development node modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,12 @@ COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 FROM base-image AS development
 
+RUN mkdir /srv/app/node_modules
+RUN chown node:node /srv/app/node_modules
+
 VOLUME /srv/.pnpm-store
 VOLUME /srv/app
+VOLUME /srv/app/node_modules
 
 USER node
 


### PR DESCRIPTION
### 📚 Description

This enables faster service startup during fullstack development and eliminates the need to run `pnpm install` when switching back from fullstack to frontend-only development.

See related `maevsi/stack` change:
- https://github.com/maevsi/stack/pull/217

cc @maevsi/contributors-active you have to rebuild the development image for vibetype (`dargstack build`) after you update your git tree to a state that includes this improvement

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
