### PR TITLE
fix(upload): unref uppy

### DIFF
--- a/src/app/components/upload/UploadGallery.vue
+++ b/src/app/components/upload/UploadGallery.vue
@@ -158,7 +158,6 @@ const pending = reactive({
 const selectedItem = ref<{
   id?: string | null
 }>()
-const uppy = ref<Uppy<{ id: string }>>()
 
 // api data
 const accountUploadQuotaBytesQuery = useAccountUploadQuotaBytesQuery({})
@@ -307,7 +306,7 @@ const getUploadBlobPromise = () =>
         if (result.error) return reject(result.error)
         if (!result.data) return
 
-        uppy.value = new Uppy({
+        const uppy = new Uppy({
           id: 'profile-picture',
           debug: !runtimeConfig.public.vio.isInProduction,
           restrictions: {
@@ -331,24 +330,24 @@ const getUploadBlobPromise = () =>
             ),
         })
 
-        uppy.value.on('restriction-failed', (_file, error) => {
+        uppy.on('restriction-failed', (_file, error: Error) => {
           return reject(error.message)
         })
 
-        uppy.value.use(Tus, {
+        uppy.use(Tus, {
           endpoint: TUSD_FILES_URL,
           limit: 1,
           removeFingerprintOnSuccess: true,
         })
 
-        uppy.value.addFile({
+        uppy.addFile({
           source: 'cropper',
           name: templateInputProfilePicture.value.files[0].name,
           type: blob.type,
           data: blob,
         })
 
-        const uploadResult = await uppy.value.upload()
+        const uploadResult = await uppy.upload()
 
         allUploadsQuery.executeQuery()
 
@@ -361,9 +360,6 @@ const getUploadBlobPromise = () =>
       'image/jpeg',
     )
   })
-
-// lifecycle
-onBeforeUnmount(() => uppy.value?.destroy())
 </script>
 
 <style>


### PR DESCRIPTION
### 📚 Description

Following https://github.com/transloadit/uppy/pull/5792, uppy can't be used in a Vue ref anymore. Therefore we just create a single instance now without any reactivity. This fixes the current error at file upload.

cc @HMDank 

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
