### PR TITLE
feat(layout): Disable viewport zoom using touch-action for #2113

### DIFF
--- a/src/app/assets/css/app.css
+++ b/src/app/assets/css/app.css
@@ -14,6 +14,11 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @layer base {
+  /* Fix for #2113: Disable zoom on webapp layout for better touch experience */
+  body {
+      touch-action: manipulation;
+  }
+  
   :disabled {
     /* cursor-not-allowed */
     @apply pointer-events-none opacity-75;


### PR DESCRIPTION
### 📚 Description

This PR implements the suggested fix from Issue #2113 by disabling unwanted zoom behavior on touch devices.

The change prevents accidental zooming (like double-tap or pinch) on mobile and tablet, which significantly improves the mobile user experience and overall layout stability of the web app.

**Resolves #2113**

---

### 📝 Checklist

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format