### PR TITLE
refactor(components): use nuxt time properties type

### DIFF
--- a/src/app/components/app/AppTime.vue
+++ b/src/app/components/app/AppTime.vue
@@ -10,46 +10,24 @@
 import { reactiveOmit } from '@vueuse/core'
 import { useForwardProps } from 'reka-ui'
 
-// TODO: use imported type (https://github.com/nuxt/nuxt/issues/29757)
-// import type { NuxtTimeProps } from '#app'
+import type { NuxtTimeProps } from '#app'
 
 const { locale: defaultLocale } = useI18n()
 const defaultTimeZone = useTimeZone()
 
-const props = withDefaults(
-  defineProps</*NuxtTimeProps*/ {
-    datetime: string | number | Date
-    day?: 'numeric' | '2-digit'
-    hour?: 'numeric' | '2-digit'
-    locale?: string
-    minute?: 'numeric' | '2-digit'
-    month?: 'numeric' | '2-digit' | 'long' | 'short' | 'narrow'
-    relative?: boolean
-    timeZone?: string
-    timeZoneName?:
-      | 'short'
-      | 'long'
-      | 'shortOffset'
-      | 'longOffset'
-      | 'shortGeneric'
-      | 'longGeneric'
-    weekday?: 'long' | 'short' | 'narrow'
-    year?: 'numeric' | '2-digit'
-  }>(),
-  {
-    // ...dateTimeFormatOptions, TODO: use shared options
-    day: 'numeric',
-    hour: 'numeric',
-    locale: undefined,
-    minute: 'numeric',
-    month: 'short',
-    relative: undefined,
-    timeZone: undefined,
-    timeZoneName: undefined,
-    weekday: undefined,
-    year: 'numeric',
-  },
-)
+const props = withDefaults(defineProps<NuxtTimeProps>(), {
+  // ...dateTimeFormatOptions, TODO: use shared options
+  day: 'numeric',
+  hour: 'numeric',
+  locale: undefined,
+  minute: 'numeric',
+  month: 'short',
+  relative: undefined,
+  timeZone: undefined,
+  timeZoneName: undefined,
+  weekday: undefined,
+  year: 'numeric',
+})
 
 const delegatedProps = reactiveOmit(props, 'locale', 'timeZone')
 const forwardedProps = useForwardProps(delegatedProps)


### PR DESCRIPTION
### 📚 Description

Use an original type.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
