### PR TITLE
fix(store)!: remove plain jwt

### DIFF
--- a/src/app/composables/auth.ts
+++ b/src/app/composables/auth.ts
@@ -1,11 +1,11 @@
 export const useAuth = async () => {
-  const jwtFromCookie = useJwtFromCookie()
+  const store = useStore()
   const authenticateAnonymous = useAuthenticateAnonymous()
-  const jwtRefreshComposable = useJwtRefresh() // TODO: rename to just `jwtRefreshComposable` when Rolldown supports variable shadowing
+  const jwtRefresh = useJwtRefresh()
 
   if (import.meta.server) {
-    if (jwtFromCookie?.jwtDecoded?.id) {
-      await jwtRefreshComposable()
+    if (store.jwtDecoded?.id) {
+      await jwtRefresh()
     } else {
       await authenticateAnonymous()
     }
@@ -38,21 +38,8 @@ export const useAuthenticateAnonymous = () => {
     })
 }
 
-export const useCookieJwt = () => {
-  const jwtName = useJwtName()
-  return useCookie(jwtName)
-}
-
-export const useJwtFromCookie = () => {
-  const cookie = useCookieJwt()
-  return getJwtFromCookie({ cookie })
-}
-
-export const useJwtName = () => getJwtName(useSiteUrl().siteUrlTyped)
-
 export const useJwtRefresh = () => {
   const { $urql, $urqlReset, ssrContext } = useNuxtApp()
-  const jwtFromCookie = useJwtFromCookie()
   const runtimeConfig = useRuntimeConfig()
   const store = useStore()
 
@@ -61,7 +48,7 @@ export const useJwtRefresh = () => {
       $urqlReset,
       client: $urql.value,
       event: ssrContext?.event,
-      id: jwtFromCookie?.jwtDecoded.id as string,
+      id: store.jwtDecoded?.id as string,
       runtimeConfig,
       store,
     })

--- a/src/app/pages/dashboard/index.vue
+++ b/src/app/pages/dashboard/index.vue
@@ -76,23 +76,12 @@ const eventQuery = graphql(`
   }
 `)
 const { $urql } = useNuxtApp()
-const jwtName = useJwtName()
-const cookieJwt = useCookieJwt()
 const {
   data: events,
   // error: recommendationError,
   pending,
 } = await useAsyncData('index-recommendations', async () => {
-  const eventIds = await $fetch(
-    '/api/service/reccoom/recommendations',
-    cookieJwt.value
-      ? {
-          headers: {
-            cookie: `${jwtName}=${cookieJwt.value}`,
-          },
-        }
-      : undefined,
-  )
+  const eventIds = await $fetch('/api/service/reccoom/recommendations')
   const events = (
     await Promise.all(
       eventIds.map(

--- a/src/app/pages/event/ingest/image.vue
+++ b/src/app/pages/event/ingest/image.vue
@@ -69,7 +69,6 @@
 
 <script setup lang="ts">
 const { t } = useI18n()
-const store = useStore()
 const alertError = useAlertError()
 const templateFileInput = useTemplateRef('fileInput')
 
@@ -126,9 +125,6 @@ const uploadFile = async () => {
     try {
       await $fetch('/api/event/ingest/image', {
         body: { base64Image },
-        headers: {
-          Authorization: `Bearer ${store.jwt}`,
-        },
         method: 'POST',
       })
       console.log('Upload success')

--- a/src/app/pages/event/ingest/url.vue
+++ b/src/app/pages/event/ingest/url.vue
@@ -31,19 +31,15 @@ definePageMeta({
 })
 
 const { t } = useI18n()
-const store = useStore()
 
 const enteredURL = ref<string>()
 
 const uploadURL = async () => {
-  if (!enteredURL.value || !store.jwt) return
+  if (!enteredURL.value) return
 
   try {
     await $fetch('/api/event/ingest/url', {
       body: { url: enteredURL.value },
-      headers: {
-        Authorization: `Bearer ${store.jwt}`,
-      },
       method: 'POST',
     })
   } catch (error) {

--- a/src/app/plugins/urql.ts
+++ b/src/app/plugins/urql.ts
@@ -15,7 +15,6 @@ import { relayPagination } from '@urql/exchange-graphcache/extras'
 import { devtoolsExchange } from '@urql/devtools'
 import { provideClient } from '@urql/vue'
 import type { Client } from '@urql/vue'
-import { consola } from 'consola'
 import type { DocumentNode } from 'graphql'
 import { ref } from 'vue'
 
@@ -177,7 +176,6 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   const runtimeConfig = useRuntimeConfig()
   const isTesting = useIsTesting()
   const getServiceHref = useGetServiceHref()
-  const store = useStore()
   const { siteUrl } = useSiteUrl()
 
   const ssrExchange = getSsrExchange({
@@ -350,17 +348,8 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       ssrExchange, // `ssrExchange` must be before `fetchExchange`
       fetchExchange,
     ],
-    fetchOptions: () => {
-      const headers = {} as Record<string, string>
-
-      if (store.jwt) {
-        consola.trace('GraphQL request authenticated with: ' + store.jwt)
-        headers.authorization = `Bearer ${store.jwt}`
-      } else {
-        consola.trace('GraphQL request without authentication.')
-      }
-
-      return { headers }
+    fetchOptions: {
+      credentials: 'include',
     },
     preferGetMethod: false, // TODO: remove with Postgraphile v5
     requestPolicy: 'cache-and-network',

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -10,7 +10,7 @@ import type { Modal } from '~/types/modal'
 export const useStore = defineStore(SITE_NAME, () => {
   const localePath = useLocalePath()
 
-  const jwt = ref<string>() // TODO: remove (https://github.com/maevsi/vibetype/issues/1720)
+  // const jwt = ref<string>() // we don't store the JWT itself for security reasons
   const jwtDecoded = ref<JWTPayload>()
   const modals = ref<Modal[]>([])
   const routeHistory = ref<string[]>([])
@@ -26,7 +26,6 @@ export const useStore = defineStore(SITE_NAME, () => {
   const jwtSet = (jwtNew?: string) => {
     const jwtDecodedNew = jwtNew !== undefined ? decodeJwt(jwtNew) : undefined
 
-    jwt.value = jwtNew
     jwtDecoded.value = jwtDecodedNew
 
     if (
@@ -68,7 +67,6 @@ export const useStore = defineStore(SITE_NAME, () => {
   }
 
   return {
-    jwt,
     jwtDecoded,
     modals,
     routeHistory,

--- a/src/app/utils/authentication.ts
+++ b/src/app/utils/authentication.ts
@@ -1,9 +1,6 @@
 import type { Client } from '@urql/vue'
 import { consola } from 'consola'
 import type { H3Event } from 'h3'
-import { decodeJwt } from 'jose'
-
-import type { CookieRef } from '#app'
 
 import { authenticateMutation } from '~~/gql/documents/mutations/account/accountAuthenticate'
 import { jwtRefreshMutation } from '~~/gql/documents/mutations/account/accountJwtRefresh'
@@ -45,29 +42,6 @@ export const authenticationAnonymous = async ({
       runtimeConfig,
       store,
     })
-  }
-}
-
-export const getJwtFromCookie = ({
-  cookie,
-}: {
-  cookie: CookieRef<string | null | undefined>
-}) => {
-  if (!cookie.value) {
-    consola.debug('No token cookie.')
-    return
-  }
-
-  const jwt = decodeJwt(cookie.value)
-
-  if (jwt.exp === undefined || jwt.exp <= Date.now() / 1000) {
-    consola.info('Token expired.')
-    return
-  }
-
-  return {
-    jwt: cookie.value,
-    jwtDecoded: jwt,
   }
 }
 

--- a/src/sentry.client.config.ts
+++ b/src/sentry.client.config.ts
@@ -14,8 +14,7 @@ if (sharedSentryConfig.dsn) {
       Sentry.httpClientIntegration(),
       Sentry.replayIntegration(),
 
-      // // enable once plain JWT isn't stored any more
-      // Sentry.piniaIntegration(usePinia()),
+      Sentry.piniaIntegration(usePinia()),
 
       // // enable if more components or hooks should be tracked
       // Sentry.vueIntegration({

--- a/src/server/api/model/event/ingest/image.post.ts
+++ b/src/server/api/model/event/ingest/image.post.ts
@@ -31,9 +31,10 @@ export default defineEventHandler(async (event) => {
   }
 
   const { client: openAiClient, getCompletionCost } = useOpenAi()
-  const { getJwtFromHeader, verifyJwt } = await useJsonWebToken()
+  const { getJwtFromCookie, verifyJwt } = await useJsonWebToken()
 
-  const jwtDecoded = await verifyJwt(getJwtFromHeader())
+  const jwt = getJwtFromCookie()
+  const jwtDecoded = await verifyJwt(jwt)
   if (!(jwtDecoded.role === `${SITE_NAME}_account`))
     return throwError({
       statusCode: 403,

--- a/src/server/api/model/event/ingest/url.post.ts
+++ b/src/server/api/model/event/ingest/url.post.ts
@@ -26,9 +26,10 @@ export default defineEventHandler(async (event) => {
   }
 
   const { client: openAiClient, getCompletionCost } = useOpenAi()
-  const { getJwtFromHeader, verifyJwt } = await useJsonWebToken()
+  const { getJwtFromCookie, verifyJwt } = await useJsonWebToken()
 
-  const jwtDecoded = await verifyJwt(getJwtFromHeader())
+  const jwt = getJwtFromCookie()
+  const jwtDecoded = await verifyJwt(jwt)
   if (!(jwtDecoded.role === `${SITE_NAME}_account`))
     return throwError({
       statusCode: 403,

--- a/src/server/utils/jwt.ts
+++ b/src/server/utils/jwt.ts
@@ -27,6 +27,7 @@ export const setJwtCookie = ({
   setCookie(event, jwtCookieName, jwt, {
     expires: jwt ? dateInAMonth : dateEpoch,
     httpOnly: true,
+    domain: siteUrl.hostname,
     // path: '/',
     sameSite: 'lax', // Cannot be 'strict' to allow authentications after clicking on links within webmailers.
     secure: isHttps,
@@ -54,18 +55,6 @@ export const useJsonWebToken = async () => {
       }
 
       return cookieAuthorization
-    },
-    getJwtFromHeader: () => {
-      const headerAuthorization = getRequestHeader(event, 'authorization')
-
-      if (!headerAuthorization) {
-        return throwError({
-          statusCode: 401,
-          statusMessage: 'The request header "Authorization" is missing!',
-        })
-      }
-
-      return headerAuthorization.substring(7)
     },
     setJwtCookie: (jwt: string) => setJwtCookie({ event, jwt, runtimeConfig }),
     verifyJwt: async (jwt: string) => {


### PR DESCRIPTION
### 📚 Description

Let's not keep the user's identity token around more than necessary. A http-only cookie is enough.

Resolves #1720 

:warning: Breaking change:
- in stack set postgraphile traefik labels
    - `accessControlAllowCredentials=true`
    - `accessControlAllowOriginList=https://${STACK_DOMAIN}`

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
