### PR TITLE
chore(sentry): make toggle information available to nuxt

### DIFF
--- a/src/.config/nuxt.ts
+++ b/src/.config/nuxt.ts
@@ -50,6 +50,7 @@ export default defineNuxtConfig({
     '@nuxt/content', // most come after `@nuxtjs/seo`
     '@nuxtjs/turnstile',
     '@pinia/nuxt',
+    '@sentry/nuxt/module',
     '@vite-pwa/nuxt',
     'nuxt-gtag',
     'shadcn-nuxt',

--- a/src/config/environments/production.ts
+++ b/src/config/environments/production.ts
@@ -2,7 +2,6 @@ import type { DefineNuxtConfig } from 'nuxt/config'
 
 export const productionConfig: ReturnType<DefineNuxtConfig> = {
   $production: {
-    modules: ['@sentry/nuxt/module'],
     runtimeConfig: {
       public: {
         vio: {
@@ -21,6 +20,9 @@ export const productionConfig: ReturnType<DefineNuxtConfig> = {
       headers: {
         crossOriginEmbedderPolicy: 'credentialless', // OpenStreepMap
       },
+    },
+    sentry: {
+      enabled: true,
     },
   },
 }

--- a/src/config/modules/index.ts
+++ b/src/config/modules/index.ts
@@ -49,6 +49,7 @@ export const modulesConfig: ReturnType<DefineNuxtConfig> = {
   },
   ...securityConfig,
   sentry: {
+    enabled: false,
     sourceMapsUploadOptions: {
       authToken: process.env.SENTRY_AUTH_TOKEN,
       org: 'maevsi',


### PR DESCRIPTION
### 📚 Description

Enable the sentry module through its own module option instead of nuxt dev/prod configuration so that Nuxt configuration knows about the module existence in any environment.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
