### PR TITLE
refactor(composables): extend authentication information by account id

### DIFF
--- a/src/app/composables/auth.ts
+++ b/src/app/composables/auth.ts
@@ -12,15 +12,29 @@ export const useAuth = async () => {
   }
 }
 
-export const useAuthInfo = () => {
+export const useAuthentication = () => {
   const store = useStore()
+
   const isSignedIn = computed(
     () => store.jwtDecoded?.role === `${SITE_NAME}_account`,
   )
+  const signedInAccountId = computed(() => store.signedInAccountId)
 
-  return {
-    isSignedIn,
-  }
+  return computed(() => {
+    if (!isSignedIn.value) {
+      return {
+        isSignedIn: false as const,
+      }
+    }
+
+    if (!signedInAccountId.value)
+      throw new Error('Inconsistent auth state: signed in but no account ID')
+
+    return {
+      isSignedIn: true as const,
+      signedInAccountId: signedInAccountId.value,
+    }
+  })
 }
 
 export const useAuthenticateAnonymous = () => {

--- a/src/app/pages/contact/index.vue
+++ b/src/app/pages/contact/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <LayoutPageTitle :title="title" />
-    <ContactList v-if="isSignedIn" />
+    <ContactList v-if="authentication.isSignedIn" />
     <LayoutCallToAction
       v-else
       :call-to-action="t('anonymousCta')"
@@ -11,7 +11,7 @@
 </template>
 
 <script setup lang="ts">
-const { isSignedIn } = useAuthInfo()
+const authentication = useAuthentication()
 const { t } = useI18n()
 
 // data

--- a/src/app/pages/dashboard/index.vue
+++ b/src/app/pages/dashboard/index.vue
@@ -6,7 +6,7 @@
   <div>
     <!-- v-else -->
     <LayoutPageTitle :title />
-    <div v-if="isSignedIn" class="flex flex-col gap-8">
+    <div v-if="authentication.isSignedIn" class="flex flex-col gap-8">
       <section
         v-if="events?.length"
         :aria-labelledby="templateIdRecommendation"
@@ -78,13 +78,13 @@ const eventQuery = graphql(`
 const { $urql } = useNuxtApp()
 const jwtName = useJwtName()
 const cookieJwt = useCookieJwt()
-const { isSignedIn } = useAuthInfo()
+const authentication = useAuthentication()
 const {
   data: events,
   // error: recommendationError,
   pending,
 } = await useAsyncData('index-recommendations', async () => {
-  if (!isSignedIn.value) return []
+  if (!authentication.value.isSignedIn) return []
 
   const eventIds = await $fetch(
     '/api/service/reccoom/recommendations',

--- a/src/app/pages/event/create.vue
+++ b/src/app/pages/event/create.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <LayoutPageTitle :is-button-event-create-shown="false" :title="title" />
-    <FormEvent v-if="isSignedIn" />
+    <FormEvent v-if="authentication.isSignedIn" />
     <LayoutCallToAction
       v-else
       :call-to-action="t('anonymousCta')"
@@ -12,7 +12,7 @@
 
 <script setup lang="ts">
 const { t } = useI18n()
-const { isSignedIn } = useAuthInfo()
+const authentication = useAuthentication()
 
 // data
 const title = t('title')

--- a/src/app/pages/index.vue
+++ b/src/app/pages/index.vue
@@ -97,7 +97,7 @@ definePageMeta({
 // achievement
 const route = useRoute()
 const store = useStore()
-const { isSignedIn } = useAuthInfo()
+const authentication = useAuthentication()
 const { t } = useI18n()
 const localePath = useLocalePath()
 const achievementUnlockMutation = useMutation(
@@ -116,7 +116,8 @@ const { /* data, */ error, status } = await useAsyncData(
     if (!Object.keys(route.query).length)
       throw new Error('Short circuit for no query parameters')
 
-    if (!isSignedIn) throw new Error('Short circuit for unauthorized access') // there's no way to be certain that a user tried to unlock an achievement here, so no prompt to login is thrown
+    if (!authentication.value.isSignedIn)
+      throw new Error('Short circuit for unauthorized access') // there's no way to be certain that a user tried to unlock an achievement here, so no prompt to login is thrown
 
     const result = await achievementUnlockMutation.executeMutation({
       code: 'c29d9fd1-e455-4f19-a62f-f89b5256a52b', // placeholder, not actually used

--- a/src/app/pages/upload/index.vue
+++ b/src/app/pages/upload/index.vue
@@ -2,7 +2,7 @@
   <div>
     <LayoutPageTitle :title="title" />
     <!-- "UploadGallery" must come after "ModalUploadSelection" for them to overlay properly! -->
-    <UploadGallery v-if="isSignedIn" />
+    <UploadGallery v-if="authentication.isSignedIn" />
     <LayoutCallToAction
       v-else
       :call-to-action="t('anonymousCta')"
@@ -13,7 +13,7 @@
 
 <script setup lang="ts">
 const { t } = useI18n()
-const { isSignedIn } = useAuthInfo()
+const authentication = useAuthentication()
 
 // data
 const title = t('title')


### PR DESCRIPTION
### 📚 Description

This pull request refactors the authentication composable and updates all relevant pages to use the new implementation. The main goal is to provide a more robust and consistent way to check authentication state and access the signed-in account ID across the app. The changes also improve error handling for inconsistent authentication states.

**Authentication composable refactor:**

- Renamed `useAuthInfo` to `useAuthentication` and changed its return value to a single computed object containing `isSignedIn` and, if signed in, `signedInAccountId`. Added error handling for inconsistent auth state.

**Page updates to use the new authentication composable:**

- Replaced all usages of `useAuthInfo` and the `isSignedIn` variable with the new `useAuthentication` composable and the `authencation.isSignedIn` property

### 📝 Checklist

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
