### PR TITLE
refactor(vue): use property shorthands

### DIFF
--- a/src/app/app.vue
+++ b/src/app/app.vue
@@ -38,7 +38,7 @@
     <VitePwaManifest />
     <ClientOnly>
       <!-- TODO: render server side too when styling is improved (https://github.com/dargmuesli/nuxt-cookie-control/discussions/228)  -->
-      <CookieControl :locale="locale" />
+      <CookieControl :locale />
     </ClientOnly>
     <!-- <div
       class="absolute inset-x-0 -top-16 -z-10 flex max-h-screen transform-gpu items-start justify-center overflow-hidden blur-3xl"

--- a/src/app/components/account/AccountProfilePicture.vue
+++ b/src/app/components/account/AccountProfilePicture.vue
@@ -1,11 +1,11 @@
 <template>
   <LoaderImage
     :alt="t('profilePictureAlt', { username: account?.username })"
-    :aspect="aspect"
+    :aspect
     :classes="classProps"
-    :height="height"
+    :height
     :src="profilePictureUrl || blankProfilePicture"
-    :width="width"
+    :width
   />
 </template>
 

--- a/src/app/components/app/AppLink.vue
+++ b/src/app/components/app/AppLink.vue
@@ -1,11 +1,11 @@
 <template>
   <NuxtLink
-    :aria-label="ariaLabel"
+    :aria-label
     :class="cn(classComputed, classProps)"
     :disabled="isDisabled"
     :external="isExternal"
     :target="targetComputed"
-    :to="to"
+    :to
     @click="emit('click')"
   >
     <slot />

--- a/src/app/components/app/button/AppButton.vue
+++ b/src/app/components/app/button/AppButton.vue
@@ -2,11 +2,11 @@
   <AppLink
     v-if="to"
     v-bind="delegatedProps"
-    :aria-label="ariaLabel"
+    :aria-label
     :class="cn(classComputed, classProps)"
     :is-disabled="disabled"
     :is-colored="false"
-    :to="to"
+    :to
     @click="emit('click')"
   >
     <slot name="prefix" />
@@ -17,11 +17,11 @@
   </AppLink>
   <button
     v-else
-    :aria-label="ariaLabel"
+    :aria-label
     :class="cn(['rounded-sm', classComputed], classProps)"
-    :disabled="disabled"
+    :disabled
     :title="ariaLabel"
-    :type="type"
+    :type
     @click="emit('click')"
   >
     <slot name="prefix" />

--- a/src/app/components/card/CardButton.vue
+++ b/src/app/components/card/CardButton.vue
@@ -15,9 +15,9 @@
         :aria-label="title"
         class="focus-visible:ring-0"
         :disabled="isDisabled"
-        :is-external="isExternal"
+        :is-external
         is-external-icon-disabled
-        :to="to"
+        :to
       >
         <span class="absolute inset-0 z-10" />
         <span class="font-bold">

--- a/src/app/components/contact/ContactAvatar.vue
+++ b/src/app/components/contact/ContactAvatar.vue
@@ -2,7 +2,7 @@
   <LoaderImage
     v-bind="delegatedProps"
     :alt="t('profilePictureAlt', { emailAddress })"
-    :cross-origin="crossOrigin"
+    :cross-origin
     :height="size"
     :src="imageSrc"
     :width="size"

--- a/src/app/components/contact/ContactList.vue
+++ b/src/app/components/contact/ContactList.vue
@@ -1,5 +1,5 @@
 <template>
-  <Loader :api="api">
+  <Loader :api>
     <div class="flex flex-col gap-4">
       <AppScrollContainer
         v-if="contacts"
@@ -33,7 +33,7 @@
               v-for="contact in contacts"
               :id="contact.nodeId"
               :key="contact.nodeId"
-              :contact="contact"
+              :contact
               :is-deleting="pending.deletions.includes(contact.nodeId)"
               :is-editing="pending.edits.includes(contact.nodeId)"
               @delete="delete_(contact.nodeId, contact.id)"

--- a/src/app/components/contact/ContactListItem.vue
+++ b/src/app/components/contact/ContactListItem.vue
@@ -7,7 +7,7 @@
     }"
   >
     <LayoutTd>
-      <ContactPreview :contact="contact" />
+      <ContactPreview :contact />
     </LayoutTd>
     <LayoutTd class="hidden xl:table-cell">
       {{ contact.emailAddress || '–' }}

--- a/src/app/components/contact/ContactPreview.vue
+++ b/src/app/components/contact/ContactPreview.vue
@@ -18,7 +18,7 @@
       <GuestFeedbackIcon
         v-if="feedback"
         class="bg-background-bright dark:bg-background-dark absolute right-0 bottom-0 rounded-full"
-        :feedback="feedback"
+        :feedback
       />
     </div>
     <div class="flex flex-col items-start justify-center overflow-hidden">

--- a/src/app/components/event/EventSearch.vue
+++ b/src/app/components/event/EventSearch.vue
@@ -1,5 +1,5 @@
 <template>
-  <Loader :api="api">
+  <Loader :api>
     <div class="flex flex-col gap-4">
       <FormInputSearch v-model="searchQuery" />
       <EventList

--- a/src/app/components/form/FormGuest.vue
+++ b/src/app/components/form/FormGuest.vue
@@ -67,7 +67,7 @@
         type="button"
         @click="selectToggle(contact.id)"
       >
-        <ContactPreview :contact="contact" :is-username-linked="false" />
+        <ContactPreview :contact :is-username-linked="false" />
         <FormCheckbox
           :is-disabled="guestContactIdsExisting?.includes(contact.id)"
           :value="

--- a/src/app/components/form/input/FormInputCaptcha.vue
+++ b/src/app/components/form/input/FormInputCaptcha.vue
@@ -19,16 +19,13 @@
     />
     <FormInputStateError
       v-if="!isVisible"
-      :form-input="formInput"
+      :form-input
       validation-property="required"
     >
       {{ t('globalValidationRequired') }}
     </FormInputStateError>
     <template v-if="isVisible" #stateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="required"
-      >
+      <FormInputStateError :form-input validation-property="required">
         {{ t('globalValidationRequired') }}
       </FormInputStateError>
     </template>

--- a/src/app/components/form/input/FormInputEmailAddress.vue
+++ b/src/app/components/form/input/FormInputEmailAddress.vue
@@ -1,7 +1,7 @@
 <template>
   <FormInput
     v-if="formInput"
-    :is-optional="isOptional"
+    :is-optional
     :id-label="`input-${id}`"
     :title="title || t('emailAddress')"
     type="email"
@@ -9,16 +9,10 @@
     @input="emit('input', $event)"
   >
     <template #stateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="lengthMax"
-      >
+      <FormInputStateError :form-input validation-property="lengthMax">
         {{ t('globalValidationLength') }}
       </FormInputStateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="required"
-      >
+      <FormInputStateError :form-input validation-property="required">
         {{ t('globalValidationRequired') }}
       </FormInputStateError>
     </template>

--- a/src/app/components/form/input/FormInputPassword.vue
+++ b/src/app/components/form/input/FormInputPassword.vue
@@ -20,27 +20,18 @@
       </ButtonIcon>
     </template>
     <template #stateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="lengthMin"
-      >
+      <FormInputStateError :form-input validation-property="lengthMin">
         {{ t('globalValidationShortness') }}
       </FormInputStateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="required"
-      >
+      <FormInputStateError :form-input validation-property="required">
         {{ t('globalValidationRequired') }}
       </FormInputStateError>
-      <FormInputStateError :form-input="formInput" validation-property="sameAs">
+      <FormInputStateError :form-input validation-property="sameAs">
         {{ t('validationSameAs') }}
       </FormInputStateError>
     </template>
     <template #stateInfo>
-      <FormInputStateInfo
-        :form-input="formInput"
-        validation-property="lengthMin"
-      >
+      <FormInputStateInfo :form-input validation-property="lengthMin">
         {{
           t('validationFormat', { length: VALIDATION_PASSWORD_LENGTH_MINIMUM })
         }}

--- a/src/app/components/form/input/FormInputPhoneNumber.vue
+++ b/src/app/components/form/input/FormInputPhoneNumber.vue
@@ -1,7 +1,7 @@
 <template>
   <FormInput
     v-if="formInput"
-    :is-optional="isOptional"
+    :is-optional
     :id-label="`input-${id}`"
     :placeholder="t('globalPlaceholderPhoneNumber')"
     :title="t('phoneNumber')"

--- a/src/app/components/form/input/FormInputUrl.vue
+++ b/src/app/components/form/input/FormInputUrl.vue
@@ -1,7 +1,7 @@
 <template>
   <FormInput
     v-if="formInput"
-    :is-optional="isOptional"
+    :is-optional
     :id-label="`input-${id}`"
     :placeholder="t('globalPlaceholderUrl')"
     :title="t('url')"
@@ -10,16 +10,10 @@
     @input="emit('input', $event)"
   >
     <template #stateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="lengthMax"
-      >
+      <FormInputStateError :form-input validation-property="lengthMax">
         {{ t('globalValidationLength') }}
       </FormInputStateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="formatUrlHttps"
-      >
+      <FormInputStateError :form-input validation-property="formatUrlHttps">
         {{ t('globalValidationFormatUrlHttps') }}
       </FormInputStateError>
     </template>

--- a/src/app/components/form/input/FormInputUsername.vue
+++ b/src/app/components/form/input/FormInputUsername.vue
@@ -1,9 +1,9 @@
 <template>
   <FormInput
     v-if="formInput"
-    :is-disabled="isDisabled"
-    :is-optional="isOptional"
-    :is-validatable="isValidatable"
+    :is-disabled
+    :is-optional
+    :is-validatable
     :id-label="`input-username`"
     :title="t('username')"
     type="text"
@@ -13,41 +13,32 @@
   >
     <template #stateError>
       <FormInputStateError
-        :form-input="formInput"
+        :form-input
         :is-validation-live="!isValidationInverted"
         validation-property="existence"
       >
         {{ t('globalValidationExistenceNone') }}
       </FormInputStateError>
       <FormInputStateError
-        :form-input="formInput"
+        :form-input
         :is-validation-live="isValidationInverted"
         validation-property="existenceNone"
       >
         {{ t('globalValidationAvailabilityNone') }}
       </FormInputStateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="formatSlug"
-      >
+      <FormInputStateError :form-input validation-property="formatSlug">
         {{ t('validationFormat') }}
       </FormInputStateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="lengthMax"
-      >
+      <FormInputStateError :form-input validation-property="lengthMax">
         {{ t('globalValidationLength') }}
       </FormInputStateError>
-      <FormInputStateError
-        :form-input="formInput"
-        validation-property="required"
-      >
+      <FormInputStateError :form-input validation-property="required">
         {{ t('globalValidationRequired') }}
       </FormInputStateError>
     </template>
     <template #stateInfo>
       <FormInputStateInfo
-        :form-input="formInput"
+        :form-input
         :is-validation-live="!isValidationInverted"
         validation-property="existence"
       >
@@ -56,10 +47,7 @@
       <slot name="stateInfo" />
     </template>
     <template v-if="!!formInput.$model && isValidatable" #stateSuccess>
-      <FormInputStateSuccess
-        :form-input="formInput"
-        validation-property="existence"
-      >
+      <FormInputStateSuccess :form-input validation-property="existence">
         {{
           isValidationInverted
             ? t('globalValidationAvailability')

--- a/src/app/components/guest/GuestList.vue
+++ b/src/app/components/guest/GuestList.vue
@@ -1,5 +1,5 @@
 <template>
-  <Loader :api="api">
+  <Loader :api>
     <div class="flex flex-col gap-4">
       <AppScrollContainer
         v-if="event && guests.length"
@@ -20,8 +20,8 @@
             <GuestListItem
               v-for="guest in guests"
               :key="guest.id"
-              :event="event"
-              :guest="guest"
+              :event
+              :guest
             />
           </LayoutTbody>
         </LayoutTable>
@@ -65,13 +65,13 @@
             v-if="!runtimeConfig.public.vio.isTesting"
             ref="doughnut"
             :data="dataComputed"
-            :options="options"
+            :options
           />
         </div>
       </div>
       <Modal id="ModalGuest" is-footer-hidden>
         <FormGuest
-          :event="event"
+          :event
           :guest-contact-ids-existing="guests.map((i) => i.contactId)"
           @submit-success="onGuestSubmitSuccess"
         />

--- a/src/app/components/guest/GuestListItem.vue
+++ b/src/app/components/guest/GuestListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <!-- <Loader :api="api" indicator="ping"> -->
+  <!-- <Loader :api indicator="ping"> -->
   <tr
     v-if="contact"
     :class="{
@@ -7,7 +7,7 @@
     }"
   >
     <LayoutTd class="max-w-0">
-      <ContactPreview :contact="contact" :feedback="guest.feedback" />
+      <ContactPreview :contact :feedback="guest.feedback" />
     </LayoutTd>
     <LayoutTd class="max-w-0">
       <div

--- a/src/app/components/layout/LayoutHeader.vue
+++ b/src/app/components/layout/LayoutHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <!-- <Loader :api="api" indicator="ping"> -->
+  <!-- <Loader :api indicator="ping"> -->
   <header>
     <div class="flex items-center justify-between gap-4">
       <div class="flex items-center gap-4">

--- a/src/app/components/loader/LoaderImage.vue
+++ b/src/app/components/loader/LoaderImage.vue
@@ -6,21 +6,14 @@
     </CardStateAlert>
     <img
       v-if="srcWhenLoaded"
-      :alt="alt"
+      :alt
       :class="cn(aspect, classes, classProps)"
       :crossorigin="crossOrigin"
-      :height="height"
+      :height
       :src="srcWhenLoaded"
-      :width="width"
+      :width
     />
-    <img
-      :alt="alt"
-      class="hidden"
-      :crossorigin="crossOrigin"
-      :height="height"
-      :src="src"
-      :width="width"
-    />
+    <img :alt class="hidden" :crossorigin="crossOrigin" :height :src :width />
   </div>
 </template>
 

--- a/src/app/components/notification/NotificationFriendRequest.vue
+++ b/src/app/components/notification/NotificationFriendRequest.vue
@@ -3,7 +3,7 @@
     <div class="flex items-center gap-4">
       <div class="px-2">
         <AccountProfilePicture
-          :account-id="accountId"
+          :account-id
           class="size-12 rounded-full"
           height="48"
           width="48"

--- a/src/app/components/upload/UploadGallery.vue
+++ b/src/app/components/upload/UploadGallery.vue
@@ -1,6 +1,6 @@
 <template>
   <Loader
-    :api="api"
+    :api
     :error-pg-ids="{
       postgres53100: t('postgres53100'),
     }"
@@ -98,7 +98,7 @@
     >
       <Cropper
         ref="cropper"
-        :init-stretcher="initStretcher"
+        :init-stretcher
         :src="fileSelectedUrl"
         :stencil-props="{
           aspectRatio: 1,

--- a/src/app/pages/contact/index.vue
+++ b/src/app/pages/contact/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <LayoutPageTitle :title="title" />
+    <LayoutPageTitle :title />
     <ContactList v-if="authentication.isSignedIn" />
     <LayoutCallToAction
       v-else

--- a/src/app/pages/docs/app.vue
+++ b/src/app/pages/docs/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-1 flex-col justify-center">
-    <!-- <LayoutPageTitle :title="title" /> -->
+    <!-- <LayoutPageTitle :title /> -->
     <div class="flex flex-col gap-8 rounded-lg p-8 text-center">
       <div class="flex flex-col gap-4">
         <div class="text-4xl leading-tight font-bold tracking-tight">

--- a/src/app/pages/docs/browser-support.vue
+++ b/src/app/pages/docs/browser-support.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <LayoutPageTitle :title="title" />
+    <LayoutPageTitle :title />
     <LayoutProse>
       <section>
         <p>

--- a/src/app/pages/event/create.vue
+++ b/src/app/pages/event/create.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <LayoutPageTitle :is-button-event-create-shown="false" :title="title" />
+    <LayoutPageTitle :is-button-event-create-shown="false" :title />
     <FormEvent v-if="authentication.isSignedIn" />
     <LayoutCallToAction
       v-else

--- a/src/app/pages/event/edit/[username]/[event_name].vue
+++ b/src/app/pages/event/edit/[username]/[event_name].vue
@@ -4,7 +4,7 @@
   <div v-else class="flex flex-col gap-4">
     <section>
       <LayoutPageTitle :title="t('title')" />
-      <FormEvent :event="event" />
+      <FormEvent :event />
     </section>
     <section>
       <h2>{{ t('titleDelete') }}</h2>

--- a/src/app/pages/event/view/[username]/[event_name]/attendance.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/attendance.vue
@@ -1,5 +1,5 @@
 <template>
-  <Loader :api="api" indicator="ping">
+  <Loader :api indicator="ping">
     <div
       v-if="event && route.params.username === store.signedInUsername"
       class="flex flex-col gap-4"

--- a/src/app/pages/event/view/[username]/[event_name]/guest.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/guest.vue
@@ -1,5 +1,5 @@
 <template>
-  <Loader :api="api">
+  <Loader :api>
     <div
       v-if="event && route.params.username === store.signedInUsername"
       class="flex flex-col gap-4"

--- a/src/app/pages/event/view/[username]/[event_name]/index.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/index.vue
@@ -68,7 +68,7 @@
     <div class="flex flex-col gap-4">
       <div>
         <div class="relative">
-          <EventHeroImage :event="event" />
+          <EventHeroImage :event />
           <div
             class="absolute inset-x-0 top-0 flex items-center justify-between p-2"
           >

--- a/src/app/pages/notification/index.vue
+++ b/src/app/pages/notification/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <LayoutPageTitle :title="title" />
+    <LayoutPageTitle :title />
     <div class="flex flex-col gap-8">
       <AppUnderConstruction>
         <div class="flex flex-col gap-8">

--- a/src/app/pages/session/edit/index.vue
+++ b/src/app/pages/session/edit/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <LayoutPageTitle :title="title" />
+    <LayoutPageTitle :title />
     <div class="flex flex-col gap-6">
       <section class="flex flex-col gap-4">
         <span class="text-lg font-bold">{{ t('profile') }}</span>

--- a/src/app/pages/session/view/index.vue
+++ b/src/app/pages/session/view/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <LayoutPageTitle :title="title" />
+    <LayoutPageTitle :title />
     <div class="flex flex-col gap-8">
       <section class="flex flex-col gap-4">
         <h2>{{ t('end') }}</h2>

--- a/src/app/pages/upload/index.vue
+++ b/src/app/pages/upload/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <LayoutPageTitle :title="title" />
+    <LayoutPageTitle :title />
     <!-- "UploadGallery" must come after "ModalUploadSelection" for them to overlay properly! -->
     <UploadGallery v-if="authentication.isSignedIn" />
     <LayoutCallToAction

--- a/src/server/assets/emails/Email.vue
+++ b/src/server/assets/emails/Email.vue
@@ -58,7 +58,7 @@ export default {
       <Container
         style="background-color: #f0f0f0; max-width: 42.5em; padding: 0 2.5em"
       >
-        <AppLogo :locale="locale" :logo-source="logoSource" />
+        <AppLogo :locale :logo-source />
         <slot />
       </Container>
     </Body>

--- a/src/server/assets/emails/EmailAccountPasswordResetRequest.vue
+++ b/src/server/assets/emails/EmailAccountPasswordResetRequest.vue
@@ -58,7 +58,7 @@ const t = locales[locale]
 </script>
 
 <template>
-  <Email :locale="locale" :logo-source="logoSource" :title="t.title">
+  <Email :locale :logo-source :title="t.title">
     <Section style="padding-top: 30px">
       <Row style="width: 45%">
         <Column>
@@ -115,7 +115,7 @@ const t = locales[locale]
         </Column>
       </Row>
     </Section>
-    <AppAuthor :locale="locale" />
-    <AppFooter :email-address="emailAddress" :locale="locale" />
+    <AppAuthor :locale />
+    <AppFooter :email-address :locale />
   </Email>
 </template>

--- a/src/server/assets/emails/EmailAccountRegistration.vue
+++ b/src/server/assets/emails/EmailAccountRegistration.vue
@@ -56,7 +56,7 @@ const t = locales[locale]
 </script>
 
 <template>
-  <Email :locale="locale" :logo-source="logoSource" :title="t.title">
+  <Email :locale :logo-source :title="t.title">
     <Section style="padding-top: 30px">
       <Row style="width: 45%">
         <Column>
@@ -100,7 +100,7 @@ const t = locales[locale]
         </Column>
       </Row>
     </Section>
-    <AppAuthor :locale="locale" />
-    <AppFooter :email-address="emailAddress" :locale="locale" />
+    <AppAuthor :locale />
+    <AppFooter :email-address :locale />
   </Email>
 </template>

--- a/src/server/assets/emails/EmailEventInvitation.vue
+++ b/src/server/assets/emails/EmailEventInvitation.vue
@@ -105,7 +105,7 @@ const t = locales[locale]
 </script>
 
 <template>
-  <Email :locale="locale" :logo-source="logoSource" :title="t.title(eventName)">
+  <Email :locale :logo-source :title="t.title(eventName)">
     <Section style="padding-top: 30px">
       <Row style="width: 45%">
         <Column>
@@ -196,6 +196,6 @@ const t = locales[locale]
         </Column>
       </Row>
     </Section>
-    <AppFooter :email-address="emailAddress" :locale="locale" />
+    <AppFooter :email-address :locale />
   </Email>
 </template>


### PR DESCRIPTION
### 📚 Description

This pull request primarily refactors how props are passed to components throughout the codebase, switching from explicit prop value bindings (e.g., `:prop="value"`) to shorthand bindings (e.g., `:prop`). This change simplifies the code, improves readability, and reduces redundancy, especially for props that are already defined in the component's script section or context. The updates are applied consistently across many components, including forms, buttons, lists, and layout elements.

These changes are purely syntactic and do not alter the runtime behavior of the application but make the codebase cleaner and easier to work with.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
