### PR TITLE
chore(middleware): redirect to app subdomain on localhost in development

### DIFF
--- a/src/.config/certificates/mkcert.sh
+++ b/src/.config/certificates/mkcert.sh
@@ -27,4 +27,4 @@ echo "key crt" | tr ' ' '\n' | while read -r glob; do
     fi
 done
 
-create "ssl" "localhost" "127.0.0.1" "0.0.0.0"
+create "ssl" "localhost" "app.localhost" "127.0.0.1" "0.0.0.0"

--- a/src/server/middleware/development.dev.ts
+++ b/src/server/middleware/development.dev.ts
@@ -1,0 +1,25 @@
+/**
+ * Development middleware that redirects requests from "localhost" to "app.localhost".
+ *
+ * Only runs in the intended development scenario (checked via runtime config) and only for requests
+ * whose hostname is exactly "localhost". The redirect preserves the original protocol and request path.
+ *
+ * Purpose:
+ * - Allow cookies set on "app.localhost" to be valid for subdomains (for example, "postgraphile.app.localhost").
+ * - Plain "localhost" cannot reliably serve domain-scoped cookies for subdomains because browsers treat
+ *   "localhost" as a special host and do not allow setting a cookie domain that covers subdomains.
+ */
+export default defineEventHandler((event) => {
+  const runtimeConfig = useRuntimeConfig(event)
+  if (!runtimeConfig.public.vio.stagingHost) return // only redirect in frontend-only development
+
+  const host = getRequestHost(event)
+  if (host?.split(':')[0] !== 'localhost') return // only redirect hostname `localhost`
+
+  const protocol = getRequestProtocol(event)
+  const newHost = host.replace('localhost', 'app.localhost')
+  const url = event.node.req.url || ''
+  const newUrl = `${protocol}://${newHost}${url}`
+
+  return sendRedirect(event, newUrl)
+})


### PR DESCRIPTION
### 📚 Description

This pull request improves local development handling of cookies and subdomains by updating SSL certificate generation and adding middleware to redirect requests from `localhost` to `app.localhost`. This ensures cookies can be set for subdomains, which is not possible with plain `localhost` due to browser restrictions.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
