### PR TITLE
fix(attendance): set record type for nfc writing

### DIFF
--- a/src/app/pages/event/view/[username]/[event_name]/attendance.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/attendance.vue
@@ -146,12 +146,17 @@ const onClick = async () => {
     }),
   })
 
-  await writeTag(
-    `https://${siteUrl.host}${localePath({
-      name: 'attendance-view-id',
-      params: { id: guestId.value },
-    })}`,
-  )
+  await writeTag({
+    records: [
+      {
+        recordType: 'url',
+        data: `https://${siteUrl.host}${localePath({
+          name: 'attendance-view-id',
+          params: { id: guestId.value },
+        })}`,
+      },
+    ],
+  })
 }
 const onDetect = async (detectedBarcodes: DetectedBarcode[]) => {
   if (!detectedBarcodes.length || !detectedBarcodes[0]) return
@@ -198,7 +203,7 @@ onMounted(() => {
     isNfcWritableErrorMessage.value = err.message
   })
 })
-const writeTag = async (data: string) => {
+const writeTag = async (data: NDEFMessageSource) => {
   try {
     await new NDEFReader().write(data)
     toast.success(t('successWrite'))

--- a/src/app/types/modules/web-nfc.d.ts
+++ b/src/app/types/modules/web-nfc.d.ts
@@ -6,21 +6,22 @@
 // This type definitions referenced to WebIDL.
 // https://w3c.github.io/web-nfc/#actual-idl-index
 
-declare type NDEFRecordDataSource = string | BufferSource | NDEFMessageInit
-
-declare interface NDEFRecordInit {
-  recordType: string
-  mediaType?: string
-  id?: string
-  encoding?: string
-  lang?: string
-  data?: NDEFRecordDataSource
+interface Window {
+  NDEFMessage: NDEFMessage
 }
-
+declare class NDEFMessage {
+  constructor(messageInit: NDEFMessageInit)
+  records: ReadonlyArray<NDEFRecord>
+}
 declare interface NDEFMessageInit {
   records: NDEFRecordInit[]
 }
 
+declare type NDEFRecordDataSource = string | BufferSource | NDEFMessageInit
+
+interface Window {
+  NDEFRecord: NDEFRecord
+}
 declare class NDEFRecord {
   constructor(recordInit: NDEFRecordInit)
   readonly recordType: string
@@ -31,34 +32,20 @@ declare class NDEFRecord {
   readonly lang?: string
   toRecords?: () => NDEFRecord[]
 }
-
-declare class NDEFMessage {
-  constructor(messageInit: NDEFMessageInit)
-  records: ReadonlyArray<NDEFRecord>
+declare interface NDEFRecordInit {
+  recordType: string
+  mediaType?: string
+  id?: string
+  encoding?: string
+  lang?: string
+  data?: NDEFRecordDataSource
 }
 
 declare type NDEFMessageSource = string | BufferSource | NDEFMessageInit
 
-interface NDEFReadingEventInit extends EventInit {
-  serialNumber?: string
-  message: NDEFMessageInit
+interface Window {
+  NDEFReader: NDEFReader
 }
-
-declare class NDEFReadingEvent extends Event {
-  constructor(type: string, readingEventInitDict: NDEFReadingEventInit)
-  serialNumber: string
-  message: NDEFMessage
-}
-
-interface NDEFWriteOptions {
-  overwrite?: boolean
-  signal?: AbortSignal
-}
-
-interface NDEFScanOptions {
-  signal: AbortSignal
-}
-
 declare class NDEFReader extends EventTarget {
   constructor()
   onreading: (this: this, event: NDEFReadingEvent) => unknown
@@ -68,4 +55,29 @@ declare class NDEFReader extends EventTarget {
     message: NDEFMessageSource,
     options?: NDEFWriteOptions,
   ) => Promise<void>
+  makeReadOnly: (options?: NDEFMakeReadOnlyOptions) => Promise<void>
+}
+
+interface Window {
+  NDEFReadingEvent: NDEFReadingEvent
+}
+declare class NDEFReadingEvent extends Event {
+  constructor(type: string, readingEventInitDict: NDEFReadingEventInit)
+  serialNumber: string
+  message: NDEFMessage
+}
+interface NDEFReadingEventInit extends EventInit {
+  serialNumber?: string
+  message: NDEFMessageInit
+}
+
+interface NDEFWriteOptions {
+  overwrite?: boolean
+  signal?: AbortSignal
+}
+interface NDEFMakeReadOnlyOptions {
+  signal?: AbortSignal
+}
+interface NDEFScanOptions {
+  signal: AbortSignal
 }


### PR DESCRIPTION
### 📚 Description

This pull request refactors how NFC tag writing is handled on the event attendance page. The main improvement is updating the `writeTag` function to accept a structured data object instead of a simple string, aligning it with the expected format for the `NDEFReader` API.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
