### PR TITLE
chore(deps): pin @nuxtjs/i18n to github:dargmuesli/nuxt-i18n#ce3f825b…

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,6 +3,10 @@
   "extends": ["github>dargmuesli/renovate-config"],
   "packageRules": [
     {
+      "allowedVersions": "github:dargmuesli/nuxt-i18n#ce3f825b0f9cb34ccd38f6ff64313e23fb07e795",
+      "matchPackageNames": ["@nuxtjs/i18n"]
+    },
+    {
       "allowedVersions": "5.1.12",
       "matchPackageNames": ["nuxt-og-image"]
     }


### PR DESCRIPTION
This pull request updates the Renovate configuration to specify an exact version for the `@nuxtjs/i18n` package. This ensures that Renovate will only allow updates to the version referenced by a specific GitHub commit, improving control over dependency updates.
