### PR TITLE
fix(app): hide cookie button on ios

### DIFF
--- a/src/app/pages/session/edit/index.vue
+++ b/src/app/pages/session/edit/index.vue
@@ -108,12 +108,9 @@
             <AppIconContract />
           </CardButton>
           <CardButton
+            v-if="!isIos"
             :title="t('cookies')"
-            @click="
-              isIos
-                ? requestTrackingPermission()
-                : (cookieControl.isModalActive.value = true)
-            "
+            @click="cookieControl.isModalActive.value = true"
           >
             <AppIconCookieOutline />
           </CardButton>


### PR DESCRIPTION
This pull request makes a targeted update to the session edit page to improve the user experience on iOS devices. Specifically, it hides the cookies settings button for iOS users, as the cookies modal is not relevant or supported on that platform.