### PR TITLE
fix(util): try to show original network error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ ENTRYPOINT ["/srv/app/docker-entrypoint.sh"]
 CMD ["pnpm", "run", "--dir", "src", "dev", "--host", "0.0.0.0"]
 EXPOSE 3000
 
-# TODO: support healthcheck while starting (https://github.com/nuxt/framework/issues/6915)
-# HEALTHCHECK --interval=10s CMD wget -O /dev/null http://localhost:3000/api/service/vibetype/healthcheck || exit 1
+# TODO: support healthcheck while starting (https://github.com/nuxt/nuxt/issues/14697)
+HEALTHCHECK --start-period=60s CMD wget -O /dev/null http://0.0.0.0:3000/api/service/vibetype/healthcheck || exit 1
 
 
 ########################

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -124,9 +124,6 @@ export default defineNuxtConfig({
       security: {
         isRateLimiterDisabled: true, // TODO: disable once api requests are optimized (https://github.com/maevsi/vibetype/issues/1654)
       },
-      turnstile: {
-        siteKey: '0x4AAAAAAABtEW1Hc8mcgWcZ',
-      },
       vio: {
         auth: {
           jwt: {

--- a/src/shared/utils/api.ts
+++ b/src/shared/utils/api.ts
@@ -48,7 +48,7 @@ export const getJwtFromResult = <
   if (result.error) {
     if (result.error.networkError) {
       throw createAppError({
-        status: 500,
+        status: result.error.response?.status || 500,
         statusText:
           (result.error.networkError.cause as { message?: string })?.message ||
           result.error.networkError.message,


### PR DESCRIPTION
This pull request makes a couple of targeted improvements: it updates error handling in the API utility to use the actual HTTP status code from failed responses, and removes the Turnstile configuration from the Nuxt config, likely as part of a configuration cleanup or feature change.