### PR TITLE
fix(account): simplify deletion variables

### DIFF
--- a/src/app/components/account/AccountDeleteDrawer.vue
+++ b/src/app/components/account/AccountDeleteDrawer.vue
@@ -20,7 +20,6 @@
         :item-name-deletion="t('account')"
         :item-name-success="t('account')"
         :mutation="accountDeleteMutation"
-        :variables="{ accountId }"
         @success="step = 'success'"
       />
     </AppStep>
@@ -111,11 +110,6 @@
 import { useMutation } from '@urql/vue'
 
 import { graphql } from '~~/gql/generated'
-
-// compiler
-const { accountId } = defineProps<{
-  accountId: string
-}>()
 
 // stepper
 const { error, restart, step } = useStepper<'password' | 'success'>()

--- a/src/app/pages/account/edit/[username].vue
+++ b/src/app/pages/account/edit/[username].vue
@@ -90,10 +90,7 @@
       >
         {{ t('deleteAccount') }}
       </ButtonColored>
-      <AccountDeleteDrawer
-        v-model:is-open="isDeleteDrawerOpen"
-        :account-id="account.rowId"
-      />
+      <AccountDeleteDrawer v-model:is-open="isDeleteDrawerOpen" />
     </div>
   </LayoutPage>
 </template>


### PR DESCRIPTION
This pull request simplifies the way the `AccountDeleteDrawer` component receives the account ID by removing the `accountId` prop and its related usage. Now, the component no longer expects the account ID to be passed as a prop from its parent.